### PR TITLE
feat: Product 도메인 CRUD + DTO / 응답에 대한 기본 처리

### DIFF
--- a/src/main/java/com/example/whathis/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/whathis/common/exception/ErrorCode.java
@@ -1,8 +1,10 @@
 package com.example.whathis.common.exception;
 
-/**
- * API 에러 코드 정의
- */
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum ErrorCode {
     
     // 400 Bad Request
@@ -29,6 +31,7 @@ public enum ErrorCode {
     ALREADY_EXISTS("ALREADY_EXISTS", "이미 존재합니다"),
     DUPLICATE_EMAIL("DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다"),
     ALREADY_LIKED("ALREADY_LIKED", "이미 좋아요한 상품입니다"),
+    NOT_LIKED("NOT_LIKED", "좋아요하지 않은 게시물입니다"),
     ALREADY_FOLLOWING("ALREADY_FOLLOWING", "이미 팔로우 중입니다"),
     OUT_OF_STOCK("OUT_OF_STOCK", "재고가 부족합니다"),
     
@@ -43,18 +46,6 @@ public enum ErrorCode {
     
     private final String code;
     private final String message;
-    
-    ErrorCode(String code, String message) {
-        this.code = code;
-        this.message = message;
-    }
-    
-    public String getCode() {
-        return code;
-    }
-    
-    public String getMessage() {
-        return message;
-    }
+
 }
 

--- a/src/main/java/com/example/whathis/product/controller/ProductController.java
+++ b/src/main/java/com/example/whathis/product/controller/ProductController.java
@@ -6,6 +6,7 @@ import com.example.whathis.product.dto.request.ProductUpdateRequest;
 import com.example.whathis.product.dto.response.ProductDetailResponse;
 import com.example.whathis.product.dto.response.ProductResponse;
 import com.example.whathis.product.service.ProductService;
+import com.example.whathis.productlike.service.ProductLikeService;
 import com.example.whathis.user.entity.User;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProductController {
 
     private final ProductService productService;
+    private final ProductLikeService productLikeService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<ProductResponse>> saveProduct(
@@ -75,6 +77,26 @@ public class ProductController {
     ) {
         productService.delete(productId, currentUser);
         return ResponseEntity.noContent().build();
+    }
+
+    // 제품 좋아요
+    @PostMapping("/{productId}/like")
+    public ResponseEntity<ApiResponse<ProductDetailResponse>> like(
+        @PathVariable Long productId,
+        @AuthenticationPrincipal User currentUser
+    ) {
+        ProductDetailResponse response = productLikeService.like(currentUser, productId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    // 제품 좋아요 취소
+    @DeleteMapping("/{productId}/like")
+    public ResponseEntity<ApiResponse<ProductDetailResponse>> unlike(
+        @PathVariable Long productId,
+        @AuthenticationPrincipal User currentUser
+    ) {
+        ProductDetailResponse response = productLikeService.unlike(currentUser, productId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
 }

--- a/src/main/java/com/example/whathis/product/service/ProductService.java
+++ b/src/main/java/com/example/whathis/product/service/ProductService.java
@@ -129,30 +129,15 @@ public class ProductService {
 
     // 제품 상세 조회
     @Transactional  // 조회수 증가를 위해 @Transactional 필요
-    public ProductDetailResponse findById(
-        Long productId, User currentUser
-    ) {
-        // 1. Product 조회 (N+1 방지: seller, category fetch join)
-        Product foundProduct = productRepository.findByIdWithSellerAndCategory(productId)
-            .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
-        
-        // 2. 조회수 증가
-        foundProduct.increaseViewCount();
-        
-        // 3. 좋아요 수 조회
-        Long likeCount = productLikeRepository.countByProductId(productId);
-        
-        // 4. 현재 사용자의 좋아요 여부 확인
-        boolean isLiked = false;
-        if (currentUser != null) {
-            isLiked = productLikeRepository.existsByUserIdAndProductId(
-                currentUser.getId(), 
-                productId
-            );
-        }
-        
-        // 5. ProductDetailResponse 반환
-        return ProductDetailResponse.from(foundProduct, likeCount, isLiked);
+    public ProductDetailResponse findById(Long productId, User currentUser) {
+        return getDetailInternal(productId, currentUser, true);
+    }
+
+    // 제품 상세 조회 (제품 정보 수정, 좋아요 요청 시 사용)
+    // 제품 정보 수정, 좋아요, 좋아요 취소 -> 조회수가 증가하지 않아야 함.
+    @Transactional(readOnly = true)
+    public ProductDetailResponse getDetail(Long productId, User currentUser) {
+        return getDetailInternal(productId, currentUser, false);
     }
     
     @Transactional
@@ -161,12 +146,14 @@ public class ProductService {
     ) {
         // 1. 로그인 체크 (테스트용: 로그인 시스템 없을 시 샘플 유저 사용)
         if (currentUser == null) {
-            // TODO: 실제 인증 시스템 구현 후 이 부분 제거하고 예외 던지기
             currentUser = userRepository.findById(1L)
-                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, 
-                    "테스트용 샘플 유저(id=1)가 DB에 없습니다."));
-            System.out.println("[테스트] 샘플 유저(id=1) 사용 중");
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
         }
+
+        // 실제 로그인 체크는 아래 if문 사용 (인증 시스템 구현 후)
+        // if (currentUser == null) {
+        //     throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
+        // }
         
         // 2. Product 조회
         Product foundProduct = productRepository.findById(productId)
@@ -198,19 +185,21 @@ public class ProductService {
         }
         
         // 6. 업데이트된 상품 반환
-        return findById(productId, currentUser);
+        return getDetail(productId, currentUser);
     }
 
     @Transactional
     public void delete(Long productId, User currentUser) {
         // 1. 로그인 체크 (테스트용: 로그인 시스템 없을 시 샘플 유저 사용)
         if (currentUser == null) {
-            // TODO: 실제 인증 시스템 구현 후 이 부분 제거하고 예외 던지기
             currentUser = userRepository.findById(1L)
-                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, 
-                    "테스트용 샘플 유저(id=1)가 DB에 없습니다."));
-            System.out.println("[테스트] 샘플 유저(id=1) 사용 중");
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
         }
+
+        // 실제 로그인 체크는 아래 if문 사용 (인증 시스템 구현 후)
+        // if (currentUser == null) {
+        //     throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
+        // }
         
         // 2. Product 조회
         Product foundProduct = productRepository.findById(productId)
@@ -228,6 +217,33 @@ public class ProductService {
         
         // 5. 삭제
         productRepository.delete(foundProduct);
+    }
+
+    private ProductDetailResponse getDetailInternal(
+        Long productId,
+        User currentUser,
+        boolean increaseViewCount
+    ) {
+        // 1. Product 조회 (N+1 방지: seller, category fetch join)
+        Product foundProduct = productRepository.findByIdWithSellerAndCategory(productId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // 2. 조회수 증가
+        if (increaseViewCount) {
+            foundProduct.increaseViewCount();
+        }
+
+        // 3. 좋아요 수 조회
+        Long likeCount = productLikeRepository.countByProductId(productId);
+
+        // 4. 현재 사용자의 좋아요 여부 확인
+        boolean isLiked = false;
+        if (currentUser != null) {
+            isLiked = productLikeRepository.existsByUserIdAndProductId(currentUser.getId(), productId);
+        }
+
+        // 5. ProductDetailResponse 반환
+        return ProductDetailResponse.from(foundProduct, likeCount, isLiked);
     }
 
 }

--- a/src/main/java/com/example/whathis/productlike/entity/ProductLike.java
+++ b/src/main/java/com/example/whathis/productlike/entity/ProductLike.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,5 +38,11 @@ public class ProductLike extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
+
+    @Builder
+    public ProductLike(User user, Product product) {
+        this.user = user;
+        this.product = product;
+    }
 
 }

--- a/src/main/java/com/example/whathis/productlike/repository/ProductLikeRepository.java
+++ b/src/main/java/com/example/whathis/productlike/repository/ProductLikeRepository.java
@@ -1,10 +1,20 @@
 package com.example.whathis.productlike.repository;
 
-import com.example.whathis.product.entity.Product;
+import com.example.whathis.productlike.entity.ProductLike;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProductLikeRepository extends JpaRepository<Product, Long> {
+public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> {
+
+    // 상품의 좋아요 수 조회
+    Long countByProductId(Long productId);
+
+    // 사용자가 특정 상품을 좋아요 했는지 확인
+    boolean existsByUserIdAndProductId(Long userId, Long productId);
+
+    // 사용자의 특정 상품 좋아요 조회
+    Optional<ProductLike> findByUserIdAndProductId(Long userId, Long productId);
 
 }

--- a/src/main/java/com/example/whathis/productlike/service/ProductLikeService.java
+++ b/src/main/java/com/example/whathis/productlike/service/ProductLikeService.java
@@ -1,13 +1,95 @@
 package com.example.whathis.productlike.service;
 
+import com.example.whathis.common.exception.BusinessException;
+import com.example.whathis.common.exception.ErrorCode;
+import com.example.whathis.product.dto.response.ProductDetailResponse;
+import com.example.whathis.product.entity.Product;
+import com.example.whathis.product.repository.ProductRepository;
+import com.example.whathis.product.service.ProductService;
+import com.example.whathis.productlike.entity.ProductLike;
 import com.example.whathis.productlike.repository.ProductLikeRepository;
+import com.example.whathis.user.entity.User;
+import com.example.whathis.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ProductLikeService {
 
     private final ProductLikeRepository productLikeRepository;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+    private final ProductService productService;
+
+    public ProductDetailResponse like(User currentUser, Long productId) {
+
+        // 1) 로그인 체크 (테스트용: 로그인 시스템 없을 시 샘플 유저 사용)
+        if (currentUser == null) {
+            currentUser = userRepository.findById(1L)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+        }
+
+        // 실제 로그인 체크는 아래 if문 사용 (인증 시스템 구현 후)
+        // if (currentUser == null) {
+        //     throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
+        // }
+
+        // 상품 존재 여부 확인
+        Product foundProduct = productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // 유저의 상품 좋아요 여부 확인
+        // 좋아요 요청을 한 번 더 보내면 발생하는 에러
+        if (productLikeRepository.existsByUserIdAndProductId(currentUser.getId(), foundProduct.getId())) {
+            throw new BusinessException(ErrorCode.ALREADY_LIKED);
+        }
+
+        // 좋아요 추가
+        ProductLike productLike = ProductLike.builder()
+                                    .user(currentUser)
+                                    .product(foundProduct)
+                                    .build();
+
+        productLikeRepository.save(productLike);
+
+        // 최신 상품 정보(좋아요 수, isLiked 포함) 반환 (조회수 증가 없이)
+        return productService.getDetail(productId, currentUser);
+    }
+
+    public ProductDetailResponse unlike(User currentUser, Long productId) {
+
+        // 1) 로그인 체크 (테스트용: 로그인 시스템 없을 시 샘플 유저 사용)
+        if (currentUser == null) {
+            currentUser = userRepository.findById(1L)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+        }
+
+        // 실제 로그인 체크는 아래 if문 사용 (인증 시스템 구현 후)
+        // if (currentUser == null) {
+        //     throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
+        // }
+
+        // 상품 존재 여부 확인
+        Product foundProduct = productRepository.findById(productId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // 좋아요를 누른 적이 없으면 에러
+        // 좋아요 취소 요청을 한 번 더 보내면 발생하는 에러
+        if (!productLikeRepository.existsByUserIdAndProductId(currentUser.getId(), foundProduct.getId())) {
+            throw new BusinessException(ErrorCode.NOT_LIKED);
+        }
+
+        // 좋아요 삭제
+        ProductLike productLike = productLikeRepository.findByUserIdAndProductId(currentUser.getId(), foundProduct.getId())
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_LIKED));
+
+        productLikeRepository.delete(productLike);
+
+        // 최신 상품 정보(좋아요 수, isLiked 포함) 반환 (조회수 증가 없이)
+        return productService.getDetail(productId, currentUser);
+    }
 
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,11 +2,11 @@
 USE whathis;
 
 -- 유저 샘플 데이터 --
-INSERT INTO users (id, email, password, name, phone_number, address, profile_image_url, brn, created_at, updated_at)
-VALUES (1, 'makersesac@sesac.com', '$2a$10$abcdEFGhijklMNOpqrstUVWXyz0123456789abcdeFGHJKLMNO', '첫째 새싹이', '010-1234-5678',
+INSERT INTO users (id, email, password, name, nickname, phone_number, address, profile_image_url, brn, created_at, updated_at)
+VALUES (1, 'makersesac@sesac.com', '$2a$10$abcdEFGhijklMNOpqrstUVWXyz0123456789abcdeFGHJKLMNO', '첫째 새싹이', "1빠", '010-1234-5678',
     '서울시 성동구 자동차시장1길 64', 'https://example.com/profile1.png', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO users (id, email, password, name, phone_number, address, profile_image_url, brn, created_at, updated_at)
-VALUES (2, 'supportersesac2@sesac.com', '$2a$10$abcdfasdfEFGhijklMNOpqrstUVWXyz0123456789abcdeFGHJKLMNO', '둘째 새싹이', '010-9876-5432',
+INSERT INTO users (id, email, password, name, nickname, phone_number, address, profile_image_url, brn, created_at, updated_at)
+VALUES (2, 'supportersesac2@sesac.com', '$2a$10$abcdfasdfEFGhijklMNOpqrstUVWXyz0123456789abcdeFGHJKLMNO', '둘째 새싹이', "2빠", '010-9876-5432',
         '서울시 성동구 자동차시장1길 65', 'https://example.com/profile2.png', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 


### PR DESCRIPTION
제품(Product)에 대한 좋아요 / 좋아요 취소 로직을 작성하였고, Postman 테스트도 성공적으로 수행하여 PR 올립니다.

### 변경 사항

- 좋아요 기능을 위한 컨트롤러를 따로 생성하지 않고, 기존에 있던 `ProductController`에 엔드포인트 추가.

- 수정(`update`), 좋아요(`like`) 및 좋아요 취소(`unlike`) 요청 시,

  - 기존에는 `ProductLikeService` 클래스에서 `productService.findById()` 메서드를 사용하여 값을 반환.
  
  - 하지만 해당 메서드는 **조회수를 증가하는 로직이 있어 수정이나 좋아요 기능만을 사용하더라도 조회수가 증가되는 버그**가 발생.
  
  - 때문에 기존의 `findById()` 메서드 내부의 로직을 `getDetailInternal()` 메서드로 분리.
  
    - 해당 메서드는 `boolean` 타입의 `increaseViewCount` 매개변수를 가져서 `update()`, `like()`, `unlike()` 요청 시에는 조회수 증가를 하지 못하도록 함.
    
    - **제품 단일 조회 API**에서 사용되는 `findById()` 메서드에서는 `increaseViewCount` 변수의 값을 `true`로 하여 조회 수를 증가하도록 설정.
    
    - **제품 정보 수정, 좋아요, 좋아요 취소 API**에서 사용되는 `getDetail()` 메서드에서는 `increaseViewCount` 변수의 값을 `false`로 하여 조회 수가 증가 하지 않도록 설정.

<br>

### 테스트

**1. 좋아요 (like)**

**[ 요청 및 응답 ]**
<img width="1000" height="739" alt="스크린샷 2025-12-21 오후 9 06 53" src="https://github.com/user-attachments/assets/0a836095-7b07-4daf-8ca0-ac48fbac1a7a" />

**[ 좋아요 이후 다시 좋아요 요청 ] - 에러 발생(정상)** 
<img width="998" height="338" alt="스크린샷 2025-12-21 오후 9 07 02" src="https://github.com/user-attachments/assets/aa94b8fb-8969-463c-9500-e36f9c8c5d52" />

**[ 좋아요 요청 후 제품 단일 조회 API 실행 ]**
<img width="1001" height="739" alt="스크린샷 2025-12-21 오후 9 07 32" src="https://github.com/user-attachments/assets/a1a1a244-2cdc-48dc-8530-2d39304485d4" />

<br>
<br>

**2. 좋아요 취소(unlike)**

**[ 요청 및 응답 ]**
<img width="1001" height="735" alt="스크린샷 2025-12-21 오후 9 07 51" src="https://github.com/user-attachments/assets/079ab327-2c40-4715-b6a4-1c39c23a9f74" />

**[ 좋아요 취소 이후 다시 좋아요 취소 요청 ] - 에러 발생(정상)**
<img width="1000" height="338" alt="스크린샷 2025-12-21 오후 9 07 59" src="https://github.com/user-attachments/assets/4091aa22-0b80-4175-9dee-9d0b7082c546" />

**[ 좋아요 취소 요청 후 제품 단일 조회 API 실행 ]**
<img width="1002" height="738" alt="스크린샷 2025-12-21 오후 9 08 16" src="https://github.com/user-attachments/assets/da207e3a-7e7c-4467-9543-b4988dbea85a" />

<br>
<br>

### 추가사항

- 좋아요 응답의 `isLiked`는 **현재 요청 사용자 기준** 값입니다.

- 인증 시스템(`User` 도메인)이 아직 없어서, 로컬 테스트 편의를 위해 **`currentUser == null`인 경우 샘플 유저(id=1) 를 사용하도록 임시 처리**했습니다.

- 따라서 전체 좋아요 수(`likeCount`) 와 요청 유저의 좋아요 여부(`isLiked`) 가 인증 유무에 따라 다르게 보일 수 있으며, 실제 인증 / 필터 로직이 적용되면 로그인 유저 기준으로 `isLiked`가 정상적으로 반영됩니다.

- 또한 조회수(`viewCount`)는 `제품 단일 조회 API`에서만 증가하도록 분리했고, `좋아요/수정 API 호출`로는 조회수가 증가하지 않도록 처리했습니다.

Closes #6 