### PR TITLE
feat/user: JWT 기반 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/whathis/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/whathis/common/exception/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     UNAUTHORIZED("UNAUTHORIZED", "인증이 필요합니다"),
     INVALID_TOKEN("INVALID_TOKEN", "유효하지 않은 토큰입니다"),
     EXPIRED_TOKEN("EXPIRED_TOKEN", "만료된 토큰입니다"),
+    INVALID_PASSWORD("INVALID_PASSWORD", "비밀번호가 일치하지 않습니다"),
+
     
     // 403 Forbidden
     FORBIDDEN("FORBIDDEN", "권한이 없습니다"),

--- a/src/main/java/com/example/whathis/common/user/UserRole.java
+++ b/src/main/java/com/example/whathis/common/user/UserRole.java
@@ -1,7 +1,0 @@
-package com.example.whathis.common.user;
-
-public enum UserRole {
-    BUYER,    // 구매자
-    SELLER,   // 판매자
-    ADMIN     // 관리자
-}

--- a/src/main/java/com/example/whathis/config/CustomUserDetails.java
+++ b/src/main/java/com/example/whathis/config/CustomUserDetails.java
@@ -1,0 +1,41 @@
+package com.example.whathis.config;
+
+import com.example.whathis.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 모든 사용자에게 기본 권한 부여
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() { return user.getPassword(); }
+
+    @Override
+    public String getUsername() { return user.getEmail(); }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/example/whathis/config/CustomUserDetailsService.java
+++ b/src/main/java/com/example/whathis/config/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.example.whathis.config;
+
+import com.example.whathis.common.exception.BusinessException;
+import com.example.whathis.common.exception.ErrorCode;
+import com.example.whathis.user.entity.User;
+import com.example.whathis.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/com/example/whathis/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/whathis/config/JwtAuthenticationFilter.java
@@ -1,7 +1,33 @@
 package com.example.whathis.config;
 
-public class JwtAuthenticationFilter {
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
-    // 작성
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = jwtProvider.resolveToken(request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Authentication authentication = jwtProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
 }

--- a/src/main/java/com/example/whathis/config/JwtProvider.java
+++ b/src/main/java/com/example/whathis/config/JwtProvider.java
@@ -1,7 +1,82 @@
 package com.example.whathis.config;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
 public class JwtProvider {
 
-    // 작성
+    private final SecretKey key;
+    private final long expiration;
+    private final UserDetailsService userDetailsService;
 
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration}") long expiration,
+            UserDetailsService userDetailsService
+    ) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expiration = expiration;
+        this.userDetailsService = userDetailsService;
+    }
+
+    public String createToken(String email) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expiration);
+
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(key)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUsername(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/com/example/whathis/config/SecurityConfig.java
+++ b/src/main/java/com/example/whathis/config/SecurityConfig.java
@@ -1,26 +1,34 @@
 package com.example.whathis.config;
 
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    // 작성
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/users/signup").permitAll()
-                        .anyRequest().authenticated()
+                        .requestMatchers("/users/signup", "/users/login").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();

--- a/src/main/java/com/example/whathis/user/controller/UserController.java
+++ b/src/main/java/com/example/whathis/user/controller/UserController.java
@@ -1,11 +1,14 @@
 package com.example.whathis.user.controller;
 
 import com.example.whathis.common.response.ApiResponse;
+import com.example.whathis.user.dto.request.LoginRequest;
 import com.example.whathis.user.dto.request.SignupRequest;
+import com.example.whathis.user.dto.response.TokenResponse;
 import com.example.whathis.user.dto.response.UserResponse;
 import com.example.whathis.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,5 +30,13 @@ public class UserController {
         UserResponse response = userService.signup(request);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenResponse>> login(
+            @Valid @RequestBody LoginRequest request
+    ) {
+        TokenResponse response = userService.login(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/example/whathis/user/controller/UserController.java
+++ b/src/main/java/com/example/whathis/user/controller/UserController.java
@@ -9,6 +9,7 @@ import com.example.whathis.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,19 +25,24 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<UserResponse>> signup(
+    public ResponseEntity<ApiResponse<Void>> signup(
             @Valid @RequestBody SignupRequest request
     ) {
-        UserResponse response = userService.signup(request);
+        userService.signup(request);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(response));
+                .body(ApiResponse.successWithMessage("회원가입이 완료되었습니다."));
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<TokenResponse>> login(
+    public ResponseEntity<ApiResponse<Void>> login(
             @Valid @RequestBody LoginRequest request
     ) {
         TokenResponse response = userService.login(request);
-        return ResponseEntity.ok(ApiResponse.success(response));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + response.getAccessToken());
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(ApiResponse.successWithMessage("로그인이 완료되었습니다."));
     }
 }

--- a/src/main/java/com/example/whathis/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/example/whathis/user/dto/request/LoginRequest.java
@@ -1,0 +1,18 @@
+package com.example.whathis.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/example/whathis/user/dto/response/TokenResponse.java
+++ b/src/main/java/com/example/whathis/user/dto/response/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.example.whathis.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenResponse {
+    private String accessToken;
+    private String tokenType;
+}

--- a/src/main/java/com/example/whathis/user/entity/User.java
+++ b/src/main/java/com/example/whathis/user/entity/User.java
@@ -1,11 +1,8 @@
 package com.example.whathis.user.entity;
 
 import com.example.whathis.BaseEntity;
-import com.example.whathis.common.user.UserRole;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;

--- a/src/main/java/com/example/whathis/user/service/UserService.java
+++ b/src/main/java/com/example/whathis/user/service/UserService.java
@@ -2,11 +2,15 @@ package com.example.whathis.user.service;
 
 import com.example.whathis.common.exception.BusinessException;
 import com.example.whathis.common.exception.ErrorCode;
+import com.example.whathis.config.JwtProvider;
+import com.example.whathis.user.dto.request.LoginRequest;
 import com.example.whathis.user.dto.request.SignupRequest;
+import com.example.whathis.user.dto.response.TokenResponse;
 import com.example.whathis.user.dto.response.UserResponse;
 import com.example.whathis.user.entity.User;
 import com.example.whathis.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.antlr.v4.runtime.Token;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +22,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtProvider  jwtProvider;
 
     @Transactional
     public UserResponse signup(SignupRequest request) {
@@ -42,4 +47,20 @@ public class UserService {
         return UserResponse.from(savedUser);
     }
 
+    @Transactional
+    public TokenResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if(!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        String token = jwtProvider.createToken(user.getEmail());
+
+        return TokenResponse.builder()
+                .accessToken(token)
+                .tokenType("Bearer")
+                .build();
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,11 +23,16 @@ spring:
   # SQL 로깅
   sql:
     init:
-      mode: always
+      mode: never
 
 # 로깅 설정
 logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql.BasicBinder: trace
+
+# JWT 설정
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  expiration: 3600000 # 1시간
 


### PR DESCRIPTION
## 작업 내용
- `build.gradle` jjwt: 0.13.0 라이브러리 추가
- `JwtProvider` 토큰 생성/검증 구현
- `JwtAuthenticationFilter` 요청 헤더의 토큰 유효성 검사 로직 구현
- `SecurityConfig` 세션 STATELESS 설정 및 로그인(/users/login) 접근 허용 및 필터 추가
- `User`의 `Controller`, `Service` 로그인 로직 추가
- `LoginRequest`, `TokenResponse` DTO 추가
- `ErrorCode` 비밀번호 불일치 예외 코드 추가
- `application.yml` JWT 시크릿 키 환경 변수 처리 및 만료 시간 설정 추가

## 특이사항
- 보안을 위해 `application.yml`에서 시크릿 키의 기본값을 제거
    - 실행 전 환경 변수 `JWT_SECRET_KEY` (32자 이상) 등록 필수
    - [https://jwtsecrets.com](https://jwtsecrets.com) 256bits의 키 발급받아 등록
- 토큰 유효시간은 임시로 3600000으로 설정

## 테스트
- 회원가입 진행 후, 해당 계정으로 로그인 요청 시 `Bearer` Access Token 정상 발급 확인

**[회원가입]**
<img width="1373" height="818" alt="signup" src="https://github.com/user-attachments/assets/8af3f64e-3f25-40b4-9a6d-4b28d8cd2943" />

**[로그인]**
<img width="1381" height="697" alt="login" src="https://github.com/user-attachments/assets/7eb68a52-4767-4b1b-83f1-33446ec773ec" />

Close #8 