### PR TITLE
refactor/auth: 인증 로직 패키지 분리 및 CORS 설정

### DIFF
--- a/src/main/java/com/example/whathis/auth/controller/AuthController.java
+++ b/src/main/java/com/example/whathis/auth/controller/AuthController.java
@@ -1,0 +1,47 @@
+package com.example.whathis.auth.controller;
+
+import com.example.whathis.auth.dto.request.LoginRequest;
+import com.example.whathis.auth.dto.request.SignupRequest;
+import com.example.whathis.auth.dto.response.TokenResponse;
+import com.example.whathis.auth.service.AuthService;
+import com.example.whathis.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Void>> signup(
+            @Valid @RequestBody SignupRequest request
+    ) {
+        authService.signup(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.successWithMessage("회원가입이 완료되었습니다."));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<Void>> login(
+            @Valid @RequestBody LoginRequest request
+    ) {
+        TokenResponse response = authService.login(request);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + response.getAccessToken());
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(ApiResponse.successWithMessage("로그인이 완료되었습니다."));
+    }
+}

--- a/src/main/java/com/example/whathis/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/example/whathis/auth/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.example.whathis.user.dto.request;
+package com.example.whathis.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/example/whathis/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/example/whathis/auth/dto/request/SignupRequest.java
@@ -1,4 +1,4 @@
-package com.example.whathis.user.dto.request;
+package com.example.whathis.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/example/whathis/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/example/whathis/auth/dto/response/TokenResponse.java
@@ -1,4 +1,4 @@
-package com.example.whathis.user.dto.response;
+package com.example.whathis.auth.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/example/whathis/auth/service/AuthService.java
+++ b/src/main/java/com/example/whathis/auth/service/AuthService.java
@@ -1,0 +1,60 @@
+package com.example.whathis.auth.service;
+
+import com.example.whathis.auth.dto.request.LoginRequest;
+import com.example.whathis.auth.dto.request.SignupRequest;
+import com.example.whathis.auth.dto.response.TokenResponse;
+import com.example.whathis.common.exception.BusinessException;
+import com.example.whathis.common.exception.ErrorCode;
+import com.example.whathis.config.JwtProvider;
+import com.example.whathis.user.entity.User;
+import com.example.whathis.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public void signup(SignupRequest request) {
+        if(userRepository.existsByEmail(request.getEmail())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        if(userRepository.existsByNickname(request.getNickname())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        User user = User.builder()
+                .email(request.getEmail())
+                .name(request.getName())
+                .nickname(request.getNickname())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .build();
+
+        userRepository.save(user);
+    }
+
+    public TokenResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if(!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        String token = jwtProvider.createToken(user.getEmail());
+
+        return TokenResponse.builder()
+                .accessToken(token)
+                .tokenType("Bearer")
+                .build();
+    }
+}

--- a/src/main/java/com/example/whathis/config/SecurityConfig.java
+++ b/src/main/java/com/example/whathis/config/SecurityConfig.java
@@ -11,6 +11,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -23,10 +28,11 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/users/signup", "/users/login").permitAll()
+                        .requestMatchers("/auth/signup", "/auth/login").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class
                 );
@@ -37,5 +43,24 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        // 현재는 개발 편의성을 위해 모든 패턴을 허용
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+
+        // 로그인 성공 시 토큰을 헤더에 포함시켜 보냄
+        // 프론트엔드에서 Authorization 헤더를 읽을 수 있도록 허용
+        configuration.setExposedHeaders(List.of("Authorization"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/example/whathis/user/controller/UserController.java
+++ b/src/main/java/com/example/whathis/user/controller/UserController.java
@@ -1,14 +1,12 @@
 package com.example.whathis.user.controller;
 
 import com.example.whathis.common.response.ApiResponse;
-import com.example.whathis.user.dto.request.LoginRequest;
-import com.example.whathis.user.dto.request.SignupRequest;
-import com.example.whathis.user.dto.response.TokenResponse;
-import com.example.whathis.user.dto.response.UserResponse;
+import com.example.whathis.auth.dto.request.LoginRequest;
+import com.example.whathis.auth.dto.request.SignupRequest;
+import com.example.whathis.auth.dto.response.TokenResponse;
 import com.example.whathis.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,25 +22,4 @@ public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<Void>> signup(
-            @Valid @RequestBody SignupRequest request
-    ) {
-        userService.signup(request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.successWithMessage("회원가입이 완료되었습니다."));
-    }
-
-    @PostMapping("/login")
-    public ResponseEntity<ApiResponse<Void>> login(
-            @Valid @RequestBody LoginRequest request
-    ) {
-        TokenResponse response = userService.login(request);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + response.getAccessToken());
-        return ResponseEntity.ok()
-                .headers(headers)
-                .body(ApiResponse.successWithMessage("로그인이 완료되었습니다."));
-    }
 }

--- a/src/main/java/com/example/whathis/user/service/UserService.java
+++ b/src/main/java/com/example/whathis/user/service/UserService.java
@@ -3,14 +3,13 @@ package com.example.whathis.user.service;
 import com.example.whathis.common.exception.BusinessException;
 import com.example.whathis.common.exception.ErrorCode;
 import com.example.whathis.config.JwtProvider;
-import com.example.whathis.user.dto.request.LoginRequest;
-import com.example.whathis.user.dto.request.SignupRequest;
-import com.example.whathis.user.dto.response.TokenResponse;
+import com.example.whathis.auth.dto.request.LoginRequest;
+import com.example.whathis.auth.dto.request.SignupRequest;
+import com.example.whathis.auth.dto.response.TokenResponse;
 import com.example.whathis.user.dto.response.UserResponse;
 import com.example.whathis.user.entity.User;
 import com.example.whathis.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.antlr.v4.runtime.Token;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,46 +20,5 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
-    private final JwtProvider  jwtProvider;
 
-    @Transactional
-    public UserResponse signup(SignupRequest request) {
-        // 이메일 중복 체크
-        if(userRepository.existsByEmail(request.getEmail())) {
-            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
-        }
-
-        // 닉네임 중복 체크
-        if(userRepository.existsByNickname(request.getNickname())) {
-            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
-        }
-
-        User user = User.builder()
-                .email(request.getEmail())
-                .name(request.getName())
-                .nickname(request.getNickname())
-                .password(passwordEncoder.encode(request.getPassword()))
-                .build();
-
-        User savedUser = userRepository.save(user);
-        return UserResponse.from(savedUser);
-    }
-
-    @Transactional
-    public TokenResponse login(LoginRequest request) {
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-
-        if(!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
-        }
-
-        String token = jwtProvider.createToken(user.getEmail());
-
-        return TokenResponse.builder()
-                .accessToken(token)
-                .tokenType("Bearer")
-                .build();
-    }
 }


### PR DESCRIPTION
## 작업 내용
- 패키지 구조 리팩토링
    - `auth`패키지 생성 및 관련 클래스 이동
        - `AuthController`, `AuthService` 추가
        - `LoginRequest`, `SignupRequest`, `TokenResponse` DTO 이동

- `SecurityConfig` 설정 수정
    - `/users/signup`, `/users/login` -> `/auth/signup`, `/auth/login` 경로 수정
    - CORS 설정 추가

## 특이 사항
프론트엔드 연동을 위해 CORS 설정 중 `setAllowedOriginPatterns`를 사용했습니다.
모든 Origin을 허용하기 위해 Patterns를 사용했습니다.

Close #15