### PR TITLE
refactor/Product : User 인증 / 인가 로직 적용

### DIFF
--- a/src/main/java/com/example/whathis/config/CustomUserDetailsService.java
+++ b/src/main/java/com/example/whathis/config/CustomUserDetailsService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {

--- a/src/main/java/com/example/whathis/product/controller/ProductController.java
+++ b/src/main/java/com/example/whathis/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.example.whathis.product.controller;
 
 import com.example.whathis.common.response.ApiResponse;
+import com.example.whathis.config.CustomUserDetails;
 import com.example.whathis.product.dto.request.ProductCreateRequest;
 import com.example.whathis.product.dto.request.ProductUpdateRequest;
 import com.example.whathis.product.dto.response.ProductDetailResponse;
@@ -34,8 +35,9 @@ public class ProductController {
     @PostMapping
     public ResponseEntity<ApiResponse<ProductResponse>> saveProduct(
         @Valid @RequestBody ProductCreateRequest request,
-        @AuthenticationPrincipal User currentUser
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        User currentUser = userDetails != null ? userDetails.getUser() : null;
         ProductResponse response = productService.save(request, currentUser);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response, "제품이 성공적으로 등록되었습니다."));
@@ -52,8 +54,10 @@ public class ProductController {
     @GetMapping("/{productId}")
     public ResponseEntity<ApiResponse<ProductDetailResponse>> findProductById(
         @PathVariable Long productId,
-        @AuthenticationPrincipal User currentUser
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        // 비로그인 사용자도 조회 가능 (isLiked는 false로 반환)
+        User currentUser = userDetails != null ? userDetails.getUser() : null;
         ProductDetailResponse response = productService.findById(productId, currentUser);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -63,8 +67,9 @@ public class ProductController {
     public ResponseEntity<ApiResponse<ProductDetailResponse>> updateProduct(
         @PathVariable Long productId,
         @Valid @RequestBody ProductUpdateRequest request,
-        @AuthenticationPrincipal User currentUser
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        User currentUser = userDetails != null ? userDetails.getUser() : null;
         ProductDetailResponse response = productService.update(productId, request, currentUser);
         return ResponseEntity.ok(ApiResponse.success(response, "제품 정보가 수정되었습니다"));
     }
@@ -73,8 +78,9 @@ public class ProductController {
     @DeleteMapping("/{productId}")
     public ResponseEntity<Void> deleteProductById(
         @PathVariable Long productId,
-        @AuthenticationPrincipal User currentUser
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        User currentUser = userDetails != null ? userDetails.getUser() : null;
         productService.delete(productId, currentUser);
         return ResponseEntity.noContent().build();
     }
@@ -83,8 +89,9 @@ public class ProductController {
     @PostMapping("/{productId}/like")
     public ResponseEntity<ApiResponse<ProductDetailResponse>> like(
         @PathVariable Long productId,
-        @AuthenticationPrincipal User currentUser
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        User currentUser = userDetails != null ? userDetails.getUser() : null;
         ProductDetailResponse response = productLikeService.like(currentUser, productId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
@@ -93,8 +100,9 @@ public class ProductController {
     @DeleteMapping("/{productId}/like")
     public ResponseEntity<ApiResponse<ProductDetailResponse>> unlike(
         @PathVariable Long productId,
-        @AuthenticationPrincipal User currentUser
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        User currentUser = userDetails != null ? userDetails.getUser() : null;
         ProductDetailResponse response = productLikeService.unlike(currentUser, productId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/example/whathis/product/entity/Product.java
+++ b/src/main/java/com/example/whathis/product/entity/Product.java
@@ -3,6 +3,7 @@ package com.example.whathis.product.entity;
 import com.example.whathis.BaseEntity;
 import com.example.whathis.category.entity.Category;
 import com.example.whathis.common.product.ProductStatus;
+import com.example.whathis.product.dto.request.ProductCreateRequest;
 import com.example.whathis.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,13 +20,15 @@ import jakarta.validation.constraints.Min;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "products")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product extends BaseEntity {
 
     @Id
@@ -89,28 +92,46 @@ public class Product extends BaseEntity {
     @Column(nullable = false)
     private String thumbnailImageUrl;
 
-    // 정적 팩토리 메서드
-    public static Product of(
-        String title, String description, User seller, Category category, BigDecimal price,
-        BigDecimal goalAmount, LocalDateTime startDate, LocalDateTime endDate, 
-        String thumbnailImageUrl, Integer inventory
+    @Builder
+    private Product(
+        String title, String description, User seller, Category category,
+        BigDecimal price, BigDecimal goalAmount, LocalDateTime startDate,
+        LocalDateTime endDate, String thumbnailImageUrl, Integer inventory
     ) {
-        Product product = new Product();
-        product.title = title;
-        product.description = description;
-        product.seller = seller;
-        product.category = category;
-        product.price = price;
-        product.goalAmount = goalAmount;
-        product.startDate = startDate;
-        product.endDate = endDate;
-        product.thumbnailImageUrl = thumbnailImageUrl;
-        product.inventory = inventory;
-        product.status = ProductStatus.PREPARING;
-        product.currentAmount = BigDecimal.ZERO;
-        product.buyerCount = 0;
-        product.viewCount = 0;
-        return product;
+        this.title = title;
+        this.description = description;
+        this.seller = seller;
+        this.category = category;
+        this.price = price;
+        this.goalAmount = goalAmount;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.thumbnailImageUrl = thumbnailImageUrl;
+        this.inventory = inventory;
+        this.status = ProductStatus.PREPARING;
+        this.currentAmount = BigDecimal.ZERO;
+        this.buyerCount = 0;
+        this.viewCount = 0;
+    }
+
+    // ProductCreateRequest DTO 객체로부터 Product 엔티티 생성
+    public static Product of(
+        ProductCreateRequest request,
+        User seller,
+        Category category
+    ) {
+        return Product.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .seller(seller)
+                .category(category)
+                .price(request.getPrice())
+                .goalAmount(request.getGoalAmount())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .thumbnailImageUrl(request.getThumbnailImageUrl())
+                .inventory(request.getInventory())
+                .build();
     }
     
     // ========== 아래부터는 비즈니스 메서드 ==========

--- a/src/main/java/com/example/whathis/product/service/ProductService.java
+++ b/src/main/java/com/example/whathis/product/service/ProductService.java
@@ -35,19 +35,10 @@ public class ProductService {
         ProductCreateRequest request,
         User currentUser
     ) {
-        // 1. 로그인 체크 (테스트용: 로그인 시스템 없을 시 샘플 유저 사용)
-        if (currentUser == null) {
-            // TODO: 실제 인증 시스템 구현 후 이 부분 제거하고 예외 던지기
-            currentUser = userRepository.findById(1L)
-                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED, 
-                    "테스트용 샘플 유저(id=1)가 DB에 없습니다. data.sql을 먼저 실행하세요."));
-            System.out.println("[테스트] 샘플 유저(id=1) 사용 중");
-        }
-
-        // 실제 로그인 체크는 아래 if문 사용 (인증 시스템 구현 후)
-        // if (currentUser == null) {
-        //     throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
-        // }
+        // 1. 유저 로그인 체크
+         if (currentUser == null) {
+             throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
+         }
         
         // 2. 사업자등록번호 체크 & 저장 (최초 상품 등록 시에만)
         if (currentUser.getBrn() == null) {
@@ -70,18 +61,7 @@ public class ProductService {
         validateProductDates(request.getStartDate(), request.getEndDate());
         
         // 5. Product 생성
-        Product product = Product.of(
-                request.getTitle(),
-                request.getDescription(),
-                currentUser,  // 판매자
-                category,
-                request.getPrice(),
-                request.getGoalAmount(),
-                request.getStartDate(),
-                request.getEndDate(),
-                request.getThumbnailImageUrl(),
-                request.getInventory()
-        );
+        Product product = Product.of(request, currentUser, category);
         
         // 6. Product 저장
         Product savedProduct = productRepository.save(product);
@@ -135,7 +115,6 @@ public class ProductService {
 
     // 제품 상세 조회 (제품 정보 수정, 좋아요 요청 시 사용)
     // 제품 정보 수정, 좋아요, 좋아요 취소 -> 조회수가 증가하지 않아야 함.
-    @Transactional(readOnly = true)
     public ProductDetailResponse getDetail(Long productId, User currentUser) {
         return getDetailInternal(productId, currentUser, false);
     }
@@ -144,16 +123,10 @@ public class ProductService {
     public ProductDetailResponse update(
         Long productId, ProductUpdateRequest request, User currentUser
     ) {
-        // 1. 로그인 체크 (테스트용: 로그인 시스템 없을 시 샘플 유저 사용)
-        if (currentUser == null) {
-            currentUser = userRepository.findById(1L)
-                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
-        }
-
-        // 실제 로그인 체크는 아래 if문 사용 (인증 시스템 구현 후)
-        // if (currentUser == null) {
-        //     throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
-        // }
+        // 1. 로그인 체크
+         if (currentUser == null) {
+             throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
+         }
         
         // 2. Product 조회
         Product foundProduct = productRepository.findById(productId)
@@ -190,16 +163,10 @@ public class ProductService {
 
     @Transactional
     public void delete(Long productId, User currentUser) {
-        // 1. 로그인 체크 (테스트용: 로그인 시스템 없을 시 샘플 유저 사용)
-        if (currentUser == null) {
-            currentUser = userRepository.findById(1L)
-                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
-        }
-
-        // 실제 로그인 체크는 아래 if문 사용 (인증 시스템 구현 후)
-        // if (currentUser == null) {
-        //     throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
-        // }
+        // 1. 로그인 체크
+         if (currentUser == null) {
+             throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
+         }
         
         // 2. Product 조회
         Product foundProduct = productRepository.findById(productId)

--- a/src/main/java/com/example/whathis/productlike/service/ProductLikeService.java
+++ b/src/main/java/com/example/whathis/productlike/service/ProductLikeService.java
@@ -9,7 +9,6 @@ import com.example.whathis.product.service.ProductService;
 import com.example.whathis.productlike.entity.ProductLike;
 import com.example.whathis.productlike.repository.ProductLikeRepository;
 import com.example.whathis.user.entity.User;
-import com.example.whathis.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,22 +19,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductLikeService {
 
     private final ProductLikeRepository productLikeRepository;
-    private final UserRepository userRepository;
     private final ProductRepository productRepository;
     private final ProductService productService;
 
     public ProductDetailResponse like(User currentUser, Long productId) {
-
-        // 1) 로그인 체크 (테스트용: 로그인 시스템 없을 시 샘플 유저 사용)
+        // 로그인 체크
         if (currentUser == null) {
-            currentUser = userRepository.findById(1L)
-                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
         }
-
-        // 실제 로그인 체크는 아래 if문 사용 (인증 시스템 구현 후)
-        // if (currentUser == null) {
-        //     throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
-        // }
 
         // 상품 존재 여부 확인
         Product foundProduct = productRepository.findById(productId)
@@ -60,17 +51,10 @@ public class ProductLikeService {
     }
 
     public ProductDetailResponse unlike(User currentUser, Long productId) {
-
-        // 1) 로그인 체크 (테스트용: 로그인 시스템 없을 시 샘플 유저 사용)
+        // 로그인 체크
         if (currentUser == null) {
-            currentUser = userRepository.findById(1L)
-                .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
         }
-
-        // 실제 로그인 체크는 아래 if문 사용 (인증 시스템 구현 후)
-        // if (currentUser == null) {
-        //     throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
-        // }
 
         // 상품 존재 여부 확인
         Product foundProduct = productRepository.findById(productId)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
   # SQL 로깅
   sql:
     init:
-      mode: never
+      mode: always
 
 # 로깅 설정
 logging:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -8,6 +8,9 @@ VALUES (1, 'makersesac@sesac.com', '$2a$10$abcdEFGhijklMNOpqrstUVWXyz0123456789a
 INSERT INTO users (id, email, password, name, nickname, phone_number, address, profile_image_url, brn, created_at, updated_at)
 VALUES (2, 'supportersesac2@sesac.com', '$2a$10$abcdfasdfEFGhijklMNOpqrstUVWXyz0123456789abcdeFGHJKLMNO', '둘째 새싹이', "2빠", '010-9876-5432',
         '서울시 성동구 자동차시장1길 65', 'https://example.com/profile2.png', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO users (id, email, password, name, nickname, phone_number, address, profile_image_url, brn, created_at, updated_at)
+VALUES (3, 'tester@sesac.com', '$2a$10$TestUserPasswordHashForTestingPurposesOnly1234567890', '셋째 새싹이', "테스터", '010-1111-2222',
+        '서울시 강남구 테헤란로 123', 'https://example.com/profile3.png', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 
 -- 카테고리 샘플 데이터 --
@@ -18,3 +21,37 @@ VALUES (1, '테크·가전', '최신 테크 & 전자기기', NULL, CURRENT_TIMES
 INSERT INTO categories (id, name, description, parent_id, created_at, updated_at)
 VALUES (2,'스마트기기', '스마트워치, 웨어러블 등', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
        (3, '홈가전', '주방·생활가전', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+
+-- 상품 샘플 데이터 --
+INSERT INTO products (id, title, description, seller_id, category_id, price, inventory, goal_amount, current_amount, buyer_count, start_date, end_date, status, view_count, thumbnail_image_url, created_at, updated_at)
+VALUES (1, '혁신적인 스마트워치 Pro', '건강 모니터링과 스마트 기능이 결합된 차세대 스마트워치입니다. 심박수, 혈압, 수면 패턴을 실시간으로 모니터링하고 50m 방수 기능을 지원합니다.', 
+        1, 2, 150000, 100, 10000000, 7500000, 50, 
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 10 DAY), DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 20 DAY), 
+        'ONGOING', 1251, 'https://example.com/smartwatch-pro.jpg', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO products (id, title, description, seller_id, category_id, price, inventory, goal_amount, current_amount, buyer_count, start_date, end_date, status, view_count, thumbnail_image_url, created_at, updated_at)
+VALUES (2, '프리미엄 무선 블렌더', '강력한 모터와 스테인레스 날로 어떤 재료도 부드럽게 갈아냅니다. USB 충전식으로 어디서나 사용 가능하며, 500ml 대용량 용기를 제공합니다.', 
+        1, 3, 89000, 200, 5000000, 4200000, 48, 
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 5 DAY), DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 15 DAY), 
+        'ONGOING', 856, 'https://example.com/blender.jpg', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+
+-- 주문 샘플 데이터 (Review 작성용) --
+INSERT INTO orders (id, order_number, buyer_id, product_id, quantity, total_amount, status, reserved_payment_date, confirmed_at, cancelled_at, cancellation_reason, created_at, updated_at)
+VALUES (1, 'ORD-20251210-A1B2C3D4', 1, 1, 2, 300000, 'CONFIRMED',
+        DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 20 DAY), 
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 3 DAY), 
+        NULL, NULL, DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 8 DAY), CURRENT_TIMESTAMP);
+
+INSERT INTO orders (id, order_number, buyer_id, product_id, quantity, total_amount, status, reserved_payment_date, confirmed_at, cancelled_at, cancellation_reason, created_at, updated_at)
+VALUES (2, 'ORD-20251212-E5F6G7H8', 2, 2, 1, 89000, 'CONFIRMED', 
+        DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 15 DAY), 
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 1 DAY), 
+        NULL, NULL, DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 5 DAY), CURRENT_TIMESTAMP);
+
+INSERT INTO orders (id, order_number, buyer_id, product_id, quantity, total_amount, status, reserved_payment_date, confirmed_at, cancelled_at, cancellation_reason, created_at, updated_at)
+VALUES (3, 'ORD-20251215-I9J0K1L2', 2, 1, 1, 150000, 'CONFIRMED',
+        DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 20 DAY), 
+        CURRENT_TIMESTAMP, 
+        NULL, NULL, DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 2 DAY), CURRENT_TIMESTAMP);


### PR DESCRIPTION
## `Product`의 CRUD 테스트를 위해 작성했던 기존의 테스트용 코드를 실제 인증 / 인가 로직을 적용한 코드로 대체

<br>

### [ 변경 사항 ]

1. 이전에 말씀드렸던 **인증 / 인가 로직 부재로 인한 `isLiked` 상태 변경 버그** 수정.
해당 버그의 내용은 아래와 같았습니다.
    - 유저가 특정 상품에 좋아요를 누르면 `isLiked = true`로 출력되어야 함.
    - 하지만 유저가 좋아요를 눌러도 `isLiked = false`로 출력.

2. `CustomUserDetailsService` 의 `UserRepository` 의존성을 `final` 설정.

3. `@AuthenticationPrincipal User currentUser` -> `@AuthenticationPrincipal CustomUserDetails userDetails`로 변경.

4. `Product` 엔티티의 `of()` 메서드 재구성.
    - `ProductCreateRequest` DTO 객체로부터 `Product` 엔티티 생성.

5. `application.yml` 의 SQL 로깅 코드 `mode: never` -> `mode: always` 로 수정.

6. `data.sql` 파일에 `orders`, `products`, `users` 샘플 데이터 추가.

<br>

### [ Postman 테스트 결과 ]
**참고 사항**
- 회원가입 이후의 화면입니다.
- 수정(update), 전체 조회(findAll) 등의 기능 결과는 변경 사항이 없어 생성(save)으로 대체합니다.

<br>1. 로그인 없이 제품 생성 시도 - 실패(정상)
<img width="747" height="424" alt="로그인 하지 않고 제품 생성 시도 (실패)" src="https://github.com/user-attachments/assets/7f29f190-c242-40d4-92e6-53958b1d8fcf" />

<br>2. 로그인 후 제품 생성 시도 - 성공
<img width="741" height="614" alt="로그인 후 제품 생성(정상 성공)" src="https://github.com/user-attachments/assets/aafad131-a7f2-4ae0-9584-002fe1df8fbb" />

<br>3. 좋아요 후, 로그인 없이 제품 단일 조회 - `isLiked=false` (정상)
<img width="751" height="611" alt="로그인 없이 제품 단일 조회(isLiked=false)" src="https://github.com/user-attachments/assets/7907f48c-020d-4bcd-b5d6-9c7dd677f1ca" />

<br>4. 좋아요 후, 로그인 상태로 제품 단일 조회 - `isLiked=true`
<img width="745" height="609" alt="로그인 후 제품 단일 조회(isLiked=true)" src="https://github.com/user-attachments/assets/81ac3d39-5a5f-4df2-b649-f13306f841c9" />

<br>
<br>

### 이와 같이 설계한 이유
> - 실제 `eCommerce`나 `OTT` 서비스에서는 로그인을 하지 않은 상태로 물품을 조회하면, 내가 로그인 상태에서 좋아요를 눌렀던 증거(좋아요 수)를 확인할 수는 있겠지만, 내가 좋아요한 제품 페이지에는 들어갈 수가 없거나 하트(좋아요)를 눌렀어도 누르지 않은 상태로 화면이 보여집니다. 
> - 때문에 `isLiked` 의 상태(`status`)를 통하여 **로그인한 유저가 좋아요한 상품의 리스트를 출력**하는 등의 사용자 경험을 제공할 수 있습니다.

<br>
<br>

Closes #17 