### PR TITLE
feat/User: User 프로필 관리 기능(조회/수정/탈퇴) 및 비밀번호 변경

### DIFF
--- a/src/main/java/com/example/whathis/auth/dto/request/PasswordUpdateRequest.java
+++ b/src/main/java/com/example/whathis/auth/dto/request/PasswordUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.example.whathis.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordUpdateRequest {
+
+    @NotBlank(message = "현재 비밀번호는 필수입니다.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호는 필수입니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 포함하여 8자 이상이어야 합니다.")
+    private String newPassword;
+
+    @NotBlank(message = "새 비밀번호 확인은 필수입니다.")
+    private String confirmNewPassword;
+}

--- a/src/main/java/com/example/whathis/auth/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/example/whathis/auth/dto/request/UserUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.example.whathis.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserUpdateRequest {
+
+    private String name;
+
+    @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하입니다.")
+    private String nickname;
+
+    private String phoneNumber;
+    private String address;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/example/whathis/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/whathis/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     MISSING_INPUT_VALUE("MISSING_INPUT_VALUE", "필수 값이 누락되었습니다"),
     PASSWORD_MISMATCH("PASSWORD_MISMATCH", "새 비밀번호가 일치하지 않습니다"),
     PASSWORD_SAME_AS_OLD("PASSWORD_SAME_AS_OLD", "기존 비밀번호와 동일합니다"),
+    SAME_AS_CURRENT_NICKNAME("SAME_AS_CURRENT_NICKNAME", "기존 닉네임과 동일합니다."),
     
     // 401 Unauthorized
     UNAUTHORIZED("UNAUTHORIZED", "인증이 필요합니다"),

--- a/src/main/java/com/example/whathis/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/whathis/common/exception/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
     INVALID_INPUT("INVALID_INPUT", "잘못된 입력 값입니다"),
     INVALID_TYPE_VALUE("INVALID_TYPE_VALUE", "잘못된 타입입니다"),
     MISSING_INPUT_VALUE("MISSING_INPUT_VALUE", "필수 값이 누락되었습니다"),
+    PASSWORD_MISMATCH("PASSWORD_MISMATCH", "새 비밀번호가 일치하지 않습니다"),
+    PASSWORD_SAME_AS_OLD("PASSWORD_SAME_AS_OLD", "기존 비밀번호와 동일합니다"),
     
     // 401 Unauthorized
     UNAUTHORIZED("UNAUTHORIZED", "인증이 필요합니다"),

--- a/src/main/java/com/example/whathis/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/whathis/common/exception/GlobalExceptionHandler.java
@@ -112,7 +112,7 @@ public class GlobalExceptionHandler {
      */
     private HttpStatus getHttpStatus(ErrorCode errorCode) {
         return switch (errorCode) {
-            case INVALID_INPUT, INVALID_TYPE_VALUE, MISSING_INPUT_VALUE -> HttpStatus.BAD_REQUEST;
+            case INVALID_INPUT, INVALID_TYPE_VALUE, MISSING_INPUT_VALUE, PASSWORD_MISMATCH, PASSWORD_SAME_AS_OLD -> HttpStatus.BAD_REQUEST;
             case UNAUTHORIZED, INVALID_TOKEN, EXPIRED_TOKEN -> HttpStatus.UNAUTHORIZED;
             case FORBIDDEN, ACCESS_DENIED -> HttpStatus.FORBIDDEN;
             case NOT_FOUND, USER_NOT_FOUND, PRODUCT_NOT_FOUND, ORDER_NOT_FOUND -> HttpStatus.NOT_FOUND;

--- a/src/main/java/com/example/whathis/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/whathis/common/exception/GlobalExceptionHandler.java
@@ -112,7 +112,7 @@ public class GlobalExceptionHandler {
      */
     private HttpStatus getHttpStatus(ErrorCode errorCode) {
         return switch (errorCode) {
-            case INVALID_INPUT, INVALID_TYPE_VALUE, MISSING_INPUT_VALUE, PASSWORD_MISMATCH, PASSWORD_SAME_AS_OLD -> HttpStatus.BAD_REQUEST;
+            case INVALID_INPUT, INVALID_TYPE_VALUE, MISSING_INPUT_VALUE, PASSWORD_MISMATCH, PASSWORD_SAME_AS_OLD, SAME_AS_CURRENT_NICKNAME -> HttpStatus.BAD_REQUEST;
             case UNAUTHORIZED, INVALID_TOKEN, EXPIRED_TOKEN -> HttpStatus.UNAUTHORIZED;
             case FORBIDDEN, ACCESS_DENIED -> HttpStatus.FORBIDDEN;
             case NOT_FOUND, USER_NOT_FOUND, PRODUCT_NOT_FOUND, ORDER_NOT_FOUND -> HttpStatus.NOT_FOUND;

--- a/src/main/java/com/example/whathis/user/controller/UserController.java
+++ b/src/main/java/com/example/whathis/user/controller/UserController.java
@@ -1,19 +1,22 @@
 package com.example.whathis.user.controller;
 
+import com.example.whathis.auth.dto.request.PasswordUpdateRequest;
+import com.example.whathis.auth.dto.request.UserUpdateRequest;
 import com.example.whathis.common.response.ApiResponse;
 import com.example.whathis.auth.dto.request.LoginRequest;
 import com.example.whathis.auth.dto.request.SignupRequest;
 import com.example.whathis.auth.dto.response.TokenResponse;
+import com.example.whathis.config.CustomUserDetails;
+import com.example.whathis.user.dto.response.UserResponse;
 import com.example.whathis.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,4 +25,37 @@ public class UserController {
 
     private final UserService userService;
 
+    @GetMapping("/profile")
+    public ResponseEntity<ApiResponse<UserResponse>> getProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        UserResponse response = userService.getProfile(userDetails.getUser());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PatchMapping("/profile")
+    public ResponseEntity<ApiResponse<UserResponse>> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserUpdateRequest request
+    ) {
+        userService.updateProfile(userDetails.getUser(), request);
+        return ResponseEntity.ok(ApiResponse.successWithMessage("회원정보가 수정되었습니다."));
+    }
+
+    @PatchMapping("/profile/password")
+    public ResponseEntity<ApiResponse<Void>> updatePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody PasswordUpdateRequest request
+    ) {
+        userService.updatePassword(userDetails.getUser(), request);
+        return ResponseEntity.ok(ApiResponse.successWithMessage("비밀번호가 변경되었습니다."));
+    }
+
+    @DeleteMapping("/profile")
+    public ResponseEntity<ApiResponse<Void>> deleteUser(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        userService.deleteUser(userDetails.getUser());
+        return ResponseEntity.ok(ApiResponse.successWithMessage("회원 탈퇴가 완료되었습니다."));
+    }
 }

--- a/src/main/java/com/example/whathis/user/entity/User.java
+++ b/src/main/java/com/example/whathis/user/entity/User.java
@@ -57,4 +57,18 @@ public class User extends BaseEntity {
         this.phoneNumber = phoneNumber;
         this.address = address;
     }
+
+    // 회원 정보 수정
+    public void updateProfile(String name, String nickname, String phoneNumber, String address, String profileImageUrl) {
+        if(name != null) this.name = name;
+        if(nickname != null) this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    // 비밀번호 수정
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/com/example/whathis/user/entity/User.java
+++ b/src/main/java/com/example/whathis/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.example.whathis.user.entity;
 
 import com.example.whathis.BaseEntity;
+import com.example.whathis.auth.dto.request.UserUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -59,12 +60,12 @@ public class User extends BaseEntity {
     }
 
     // 회원 정보 수정
-    public void updateProfile(String name, String nickname, String phoneNumber, String address, String profileImageUrl) {
-        if(name != null) this.name = name;
-        if(nickname != null) this.nickname = nickname;
-        this.phoneNumber = phoneNumber;
-        this.address = address;
-        this.profileImageUrl = profileImageUrl;
+    public void updateProfile(UserUpdateRequest request) {
+        if (request.getName() != null) this.name = request.getName();
+        if (request.getNickname() != null) this.nickname = request.getNickname();
+        if (request.getPhoneNumber() != null) this.phoneNumber = request.getPhoneNumber();
+        if (request.getAddress() != null) this.address = request.getAddress();
+        if (request.getProfileImageUrl() != null) this.profileImageUrl = request.getProfileImageUrl();
     }
 
     // 비밀번호 수정

--- a/src/main/java/com/example/whathis/user/service/UserService.java
+++ b/src/main/java/com/example/whathis/user/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
     }
 
     @Transactional
-    public UserResponse updatePassword(User user, PasswordUpdateRequest request) {
+    public void updatePassword(User user, PasswordUpdateRequest request) {
         if(!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
@@ -68,8 +68,6 @@ public class UserService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         currentUser.updatePassword(passwordEncoder.encode(request.getNewPassword()));
-
-        return  UserResponse.from(currentUser);
     }
 
     @Transactional

--- a/src/main/java/com/example/whathis/user/service/UserService.java
+++ b/src/main/java/com/example/whathis/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.example.whathis.user.service;
 
+import com.example.whathis.auth.dto.request.PasswordUpdateRequest;
+import com.example.whathis.auth.dto.request.UserUpdateRequest;
 import com.example.whathis.common.exception.BusinessException;
 import com.example.whathis.common.exception.ErrorCode;
 import com.example.whathis.config.JwtProvider;
@@ -20,5 +22,62 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
+    public UserResponse getProfile(User user) {
+        return UserResponse.from(user);
+    }
+
+    @Transactional
+    public UserResponse updateProfile(User user, UserUpdateRequest request) {
+        if(request.getNickname() != null &&
+                !user.getNickname().equals(request.getNickname()) &&
+                userRepository.existsByNickname(request.getNickname())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        User currentUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        currentUser.updateProfile(
+                request.getName(),
+                request.getNickname(),
+                request.getPhoneNumber(),
+                request.getAddress(),
+                request.getProfileImageUrl()
+        );
+
+        return UserResponse.from(currentUser);
+    }
+
+    @Transactional
+    public UserResponse updatePassword(User user, PasswordUpdateRequest request) {
+        if(!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        if(passwordEncoder.matches(request.getNewPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.PASSWORD_SAME_AS_OLD);
+        }
+
+        if(!request.getNewPassword().equals(request.getConfirmNewPassword())) {
+            throw new BusinessException(ErrorCode.PASSWORD_MISMATCH);
+        }
+
+        User currentUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        currentUser.updatePassword(passwordEncoder.encode(request.getNewPassword()));
+
+        return  UserResponse.from(currentUser);
+    }
+
+    @Transactional
+    public void deleteUser(User user) {
+        User currentUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 진행중인 펀딩이나 주문이 있는지 확인하는 로직은 추후에 추가
+        userRepository.delete(currentUser);
+    }
 }

--- a/src/main/java/com/example/whathis/user/service/UserService.java
+++ b/src/main/java/com/example/whathis/user/service/UserService.java
@@ -18,39 +18,35 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional(readOnly = true)
     public UserResponse getProfile(User user) {
         return UserResponse.from(user);
     }
 
-    @Transactional
     public UserResponse updateProfile(User user, UserUpdateRequest request) {
-        if(request.getNickname() != null &&
-                !user.getNickname().equals(request.getNickname()) &&
-                userRepository.existsByNickname(request.getNickname())) {
-            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
-        }
-
         User currentUser = userRepository.findById(user.getId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        currentUser.updateProfile(
-                request.getName(),
-                request.getNickname(),
-                request.getPhoneNumber(),
-                request.getAddress(),
-                request.getProfileImageUrl()
-        );
+        if (request.getNickname() != null) {
+            if (currentUser.getNickname().equals(request.getNickname())) {
+                throw new BusinessException(ErrorCode.SAME_AS_CURRENT_NICKNAME);
+            }
+            if (userRepository.existsByNickname(request.getNickname())) {
+                throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+            }
+        }
+
+        currentUser.updateProfile(request);
 
         return UserResponse.from(currentUser);
     }
 
-    @Transactional
     public void updatePassword(User user, PasswordUpdateRequest request) {
         if(!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
@@ -70,7 +66,6 @@ public class UserService {
         currentUser.updatePassword(passwordEncoder.encode(request.getNewPassword()));
     }
 
-    @Transactional
     public void deleteUser(User user) {
         User currentUser = userRepository.findById(user.getId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));


### PR DESCRIPTION
사용자의 계정 정보 관리(조회, 수정, 탈퇴) 및 비밀번호 변경 기능을 작성했습니다.

##  작업 내용
- `User`에 `updateProfile`, `updatePassword` 메서드 추가
- `UserUpdateRequest`, `PasswordUpdateRequest` DTO 추가
- `UserService` 정보 수정, 비밀번호 변경, 회원 탈퇴 로직 작성
    - 닉네임 변경 시 중복 검사 수행
    - 비밀번호 변경 시 기존 비밀번호와 다른지 검증 후 새 비밀번호로 변경
- `UserController` 프로필 조회/수정/탈퇴, 비밀번호 변경 API 작성

##  특이사항
- 비밀번호 변경 API 분리: 비밀번호 변경은 보안이 중요하므로 `PATCH /users/me/password`로 엔드포인트를 분리했습니다.
- 회원 탈퇴 시 진행중인 펀딩이나 주문이 있는지 확인하는 로직은 Order 클래스 작성 완료 후 추가할 예정입니다.

## 테스트
**[회원정보 조회]**
<img width="1387" height="815" alt="get profile" src="https://github.com/user-attachments/assets/efe402b0-01ed-4593-9976-0b77253c2851" />

**[회원정보 수정]**
<img width="1382" height="613" alt="update profile" src="https://github.com/user-attachments/assets/ed869712-1e3d-4aa8-aa28-5e0d4ce1ee62" />

**[수정한 회원정보 조회]**
<img width="1370" height="822" alt="get update_profile" src="https://github.com/user-attachments/assets/935f2a62-6576-4440-9560-110c2a5cdbaf" />

**[기존 비밀번호와 변경할 비밀번호가 같은 경우 에러]**
<img width="1373" height="682" alt="same password" src="https://github.com/user-attachments/assets/0a953afc-4372-400d-b48e-c78840a3851c" />

**[비밀번호 변경]**
<img width="1391" height="632" alt="update pw" src="https://github.com/user-attachments/assets/e54b1d63-9e65-463a-8bf9-4b6daf50dc17" />

**[변경 전 비밀번호로 로그인 시 에러]**
<img width="1385" height="710" alt="fail login" src="https://github.com/user-attachments/assets/fa6dc7eb-ef3a-4574-9c04-4d5ec5c87673" />

**[변경한 비밀번호로 로그인 시 성공]**
<img width="1396" height="657" alt="success login" src="https://github.com/user-attachments/assets/6c11219d-70b6-40f6-9a85-c3bef5867777" />

**[회원 탈퇴]**
<img width="1393" height="617" alt="delete user" src="https://github.com/user-attachments/assets/ad1e9bcf-921a-4e54-9383-e23fb55167c6" />

**[탈퇴한 계정으로 로그인 시 에러]**
<img width="1388" height="688" alt="user not found" src="https://github.com/user-attachments/assets/fec4041c-0fe9-4077-8f6f-5c7d484f39c4" />

Close #19 