### PR TITLE
refactor/ProductLike : 제품 좋아요 검증 로직 추가

### DIFF
--- a/src/main/java/com/example/whathis/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/whathis/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     // 403 Forbidden
     FORBIDDEN("FORBIDDEN", "권한이 없습니다"),
     ACCESS_DENIED("ACCESS_DENIED", "접근이 거부되었습니다"),
+    CANNOT_SELF_LIKE("CANNOT_SELF_LIKE", "본인의 제품에는 좋아요를 누를 수 없습니다."),
     
     // 404 Not Found
     NOT_FOUND("NOT_FOUND", "리소스를 찾을 수 없습니다"),

--- a/src/main/java/com/example/whathis/productlike/service/ProductLikeService.java
+++ b/src/main/java/com/example/whathis/productlike/service/ProductLikeService.java
@@ -32,6 +32,11 @@ public class ProductLikeService {
         Product foundProduct = productRepository.findById(productId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
+        // 본인의 제품에는 좋아요 불가능
+        if (foundProduct.getSeller().getId().equals(currentUser.getId())) {
+            throw new BusinessException(ErrorCode.CANNOT_SELF_LIKE);
+        }
+
         // 유저의 상품 좋아요 여부 확인
         // 좋아요 요청을 한 번 더 보내면 발생하는 에러
         if (productLikeRepository.existsByUserIdAndProductId(currentUser.getId(), foundProduct.getId())) {


### PR DESCRIPTION
## 본인이 등록한 제품에 좋아요를 누를 수 있는 버그 수정

### [ 변경 사항 ]
- `ProductLikeService.java`의 `save()` 메서드.

  - 제품 판매자(`Product.seller`)와 현재 로그인한 유저(`currentUser`)가 같은 지 검증(`id` 비교)하는 로직 추가.
   
- `ErrorCode.java`.

  - `CANNOT_SELF_LIKE` 추가.

---

### [ Postman 테스트 결과 ]
### 참고 사항 - 테스트 유저가 등록한 제품의 id: `3`

<br>**1. 다른 유저가 등록한 제품에 좋아요 - 성공**
<img width="749" height="620" alt="스크린샷 2025-12-23 오후 4 13 03" src="https://github.com/user-attachments/assets/f626b91c-a532-45c5-98f7-0a464b405245" />

**<br>2. 본인이 등록한 제품에 좋아요 - 실패(정상)**
<img width="749" height="469" alt="스크린샷 2025-12-23 오후 4 11 56" src="https://github.com/user-attachments/assets/d052c95e-cd0a-4cda-87f8-a84bc542b11a" />

<br>
<br>

Closes #21 