### PR TITLE
feat/Category : 카테고리 도메인 기본 CRUD 작성

### DIFF
--- a/src/main/java/com/example/whathis/category/controller/CategoryController.java
+++ b/src/main/java/com/example/whathis/category/controller/CategoryController.java
@@ -1,7 +1,12 @@
 package com.example.whathis.category.controller;
 
+import com.example.whathis.category.dto.response.CategoryResponse;
 import com.example.whathis.category.service.CategoryService;
+import com.example.whathis.common.response.ApiResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,5 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class CategoryController {
 
     private final CategoryService categoryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CategoryResponse>>> findAllCategories() {
+        List<CategoryResponse> responses = categoryService.findAll();
+        return ResponseEntity.ok(ApiResponse.success(responses));
+    }
 
 }

--- a/src/main/java/com/example/whathis/category/dto/response/CategoryResponse.java
+++ b/src/main/java/com/example/whathis/category/dto/response/CategoryResponse.java
@@ -1,0 +1,26 @@
+package com.example.whathis.category.dto.response;
+
+import com.example.whathis.category.entity.Category;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryResponse {
+
+    private Long id;
+
+    private String name;
+
+    public static CategoryResponse from(Category category) {
+        return CategoryResponse.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/whathis/category/entity/Category.java
+++ b/src/main/java/com/example/whathis/category/entity/Category.java
@@ -3,16 +3,10 @@ package com.example.whathis.category.entity;
 import com.example.whathis.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,16 +22,5 @@ public class Category extends BaseEntity {
 
     @Column(nullable = false)
     private String name;
-
-    private String description;
-
-    // 계층 구조 (부모 카테고리)
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_id")
-    private Category parent;
-
-    // 자식 카테고리
-    @OneToMany(mappedBy = "parent")
-    private List<Category> children = new ArrayList<>();
 
 }

--- a/src/main/java/com/example/whathis/category/service/CategoryService.java
+++ b/src/main/java/com/example/whathis/category/service/CategoryService.java
@@ -1,13 +1,27 @@
 package com.example.whathis.category.service;
 
+import com.example.whathis.category.dto.response.CategoryResponse;
+import com.example.whathis.category.entity.Category;
 import com.example.whathis.category.repository.CategoryRepository;
+import com.example.whathis.product.dto.response.ProductResponse;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
+
+    public List<CategoryResponse> findAll() {
+        List<Category> categoryList = categoryRepository.findAll();
+        return categoryList.stream()
+                .map(CategoryResponse::from)
+                .collect(Collectors.toList());
+    }
 
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -13,26 +13,34 @@ VALUES (3, 'tester@sesac.com', '$2a$10$TestUserPasswordHashForTestingPurposesOnl
         '서울시 강남구 테헤란로 123', 'https://example.com/profile3.png', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 
--- 카테고리 샘플 데이터 --
--- 1. 상위 카테고리 (1개)
-INSERT INTO categories (id, name, created_at, updated_at)
-VALUES (1, '테크·가전', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
--- 2. 하위 카테고리 (2개)
-INSERT INTO categories (id, name, created_at, updated_at)
-VALUES (2,'스마트기기', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-       (3, '홈가전', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+-- 카테고리 샘플 데이터 (다양한 도메인 추가) --
+INSERT INTO categories (id, name, created_at, updated_at) VALUES 
+(1, '가전·디지털', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+(2, '패션·잡화', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+(3, '뷰티·코스메틱', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+(4, '푸드', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+(5, '홈·리빙', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+(6, '스포츠·아웃도어', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+(7, '반려동물', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+(8, '게임·취미', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+(9, '디자인·문구', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+(10, '여행·레저', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+(11, '출판', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+(12, '기부·후원', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 
--- 상품 샘플 데이터 --
+-- 상품 샘플 데이터 (카테고리 ID 매핑 수정) --
+-- Product 1: 스마트워치 -> 테크·가전 (ID: 1)
 INSERT INTO products (id, title, description, seller_id, category_id, price, inventory, goal_amount, current_amount, buyer_count, start_date, end_date, status, view_count, thumbnail_image_url, created_at, updated_at)
 VALUES (1, '혁신적인 스마트워치 Pro', '건강 모니터링과 스마트 기능이 결합된 차세대 스마트워치입니다. 심박수, 혈압, 수면 패턴을 실시간으로 모니터링하고 50m 방수 기능을 지원합니다.', 
-        1, 2, 150000, 100, 10000000, 7500000, 50, 
+        1, 1, 150000, 100, 10000000, 7500000, 50, 
         DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 10 DAY), DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 20 DAY), 
         'ONGOING', 1251, 'https://example.com/smartwatch-pro.jpg', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
+-- Product 2: 블렌더 -> 홈·리빙 (ID: 5)
 INSERT INTO products (id, title, description, seller_id, category_id, price, inventory, goal_amount, current_amount, buyer_count, start_date, end_date, status, view_count, thumbnail_image_url, created_at, updated_at)
 VALUES (2, '프리미엄 무선 블렌더', '강력한 모터와 스테인레스 날로 어떤 재료도 부드럽게 갈아냅니다. USB 충전식으로 어디서나 사용 가능하며, 500ml 대용량 용기를 제공합니다.', 
-        1, 3, 89000, 200, 5000000, 4200000, 48, 
+        1, 5, 89000, 200, 5000000, 4200000, 48, 
         DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 5 DAY), DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 15 DAY), 
         'ONGOING', 856, 'https://example.com/blender.jpg', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 


### PR DESCRIPTION
## Category 도메인의 기본적인 CRUD 코드를 작성하였습니다.

- `Category`를 현재처럼 엔티티로 나눌 것인지, Product 생성 때 내부의 필드로 둘 것인지에 대해서는 전자를 채택.

- 하지만 관리자 계정이 따로 있지 않은 현재의 상태에서는 `생성(C)`, `수정(U)`, `삭제(D)` 보다는 **`전체 조회(R)`** 하나만 존재하는 것이 좋다고 판단.

- 위의 이유로 `data.sql` 파일 내에 `Category` 관련 샘플 데이터를 만들어 사용하는 방식으로 코드를 작성하였습니다.

<br>

### [ Postman 테스트 결과 ]

**1. 카테고리 전체 조회 API**

**[ 요청 ]**

<img width="750" height="102" alt="카테고리 전체 조회 요청" src="https://github.com/user-attachments/assets/ce0c75fd-2bc7-49a2-ae00-f1f7e4573568" />

<br>**[ 응답 ]**

<img width="743" height="416" alt="카테고리 전체 조회 응답 1" src="https://github.com/user-attachments/assets/60de6a8d-8e7d-4769-b654-9dc756369034" />
<img width="741" height="362" alt="카테고리 전체 조회 응답 2" src="https://github.com/user-attachments/assets/30769b2e-9260-4b2c-821a-90527e0e755b" />
<img width="746" height="258" alt="카테고리 전체 조회 응답 3" src="https://github.com/user-attachments/assets/f1675477-a77f-4b20-ba98-762f2e56bd24" />

<br>

<br>**2. 제품 생성 API**

**[ 요청 ]**

<img width="752" height="407" alt="제품 생성 API" src="https://github.com/user-attachments/assets/5fc54c16-bbf2-44e8-86a9-22b7bba8fb57" />

<br>**[ 응답 ]**

<img width="747" height="483" alt="제품 생성 API 응답 1" src="https://github.com/user-attachments/assets/aca40af8-f0d6-4b5e-ad0e-88f0779288b2" />
<img width="746" height="224" alt="제품 생성 API 응답 2" src="https://github.com/user-attachments/assets/49fab3dc-e32f-4183-a5bc-d1456c9b6964" />

<br>
<br>

Closes #24 