### PR TITLE
feat/User: 판매자 프로필 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/whathis/config/SecurityConfig.java
+++ b/src/main/java/com/example/whathis/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/signup", "/auth/login", "/auth/kakao").permitAll()
                         .requestMatchers("/products/**").permitAll()    // Product API 허용 (테스트용)
                         .requestMatchers("/categories/**").permitAll()  // Category API 허용 (테스트용)
+                        .requestMatchers("/users/profile/{userId}").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class
                 );

--- a/src/main/java/com/example/whathis/product/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/example/whathis/product/dto/response/UserProfileResponse.java
@@ -1,0 +1,55 @@
+package com.example.whathis.product.dto.response;
+
+import com.example.whathis.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Builder
+public class UserProfileResponse {
+    // 사용자 정보
+    private Long id;
+    private String name;
+    private String nickname;
+    private String profileImageUrl;
+    private String brn;
+
+    // 통계 정보
+    private Long followerCount;
+    private Double ratingAvg;
+    private BigDecimal salesTotalAmount;
+
+    // 팔로우 여부
+    @JsonProperty("following")
+    private boolean isFollowing;
+
+    // 판매 중인 상품 목록
+    private List<ProductResponse> products;
+
+    public static UserProfileResponse of(
+            User user,
+            Long followerCount,
+            Double ratingAvg,
+            BigDecimal salesTotalAmount,
+            boolean isFollowing,
+            List<ProductResponse> products
+
+    ) {
+        return UserProfileResponse.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .brn(user.getBrn())
+                .followerCount(followerCount)
+                .ratingAvg(ratingAvg)
+                .salesTotalAmount(salesTotalAmount)
+                .isFollowing(isFollowing)
+                .products(products)
+                .build();
+    }
+}

--- a/src/main/java/com/example/whathis/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/whathis/product/repository/ProductRepository.java
@@ -1,6 +1,5 @@
 package com.example.whathis.product.repository;
 
-import com.example.whathis.common.product.ProductStatus;
 import com.example.whathis.product.entity.Product;
 import com.example.whathis.user.entity.User;
 import java.math.BigDecimal;
@@ -47,17 +46,24 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findAllMyProducts(@Param("sellerId") Long sellerId);
 
     // 특정 사용자의 총 누적 판매 금액 조회
+    // 성공으로 종료된 상품의 누적 판매 금액이므로 endDate(판매 종료일)가 현재보다 과거여야하고,
+    // 현재 모금액이 목표 모금액 이상이어야 함
     @Query("SELECT SUM(p.currentAmount) " +
             "FROM Product p " +
             "WHERE p.seller.id = :sellerId " +
-            "AND p.status = :status")
-    BigDecimal sumSalesTotalBySellerId(@Param("sellerId") Long sellerId, @Param("status") ProductStatus status);
+            "AND p.endDate < CURRENT_TIMESTAMP " +
+            "AND p.currentAmount >= p.goalAmount")
+    BigDecimal sumSalesTotalBySellerId(@Param("sellerId") Long sellerId);
 
     // 특정 사용자의 진행 중인 상품 목록 조회
+    // startDate(시작일)는 지났고 endDate(종료일)은 지나지 않은 상품
     @Query("SELECT p " +
-            "FROM Product p JOIN FETCH p.seller LEFT JOIN FETCH p.category " +
+            "FROM Product p " +
+            "JOIN FETCH p.seller " +
+            "LEFT JOIN FETCH p.category " +
             "WHERE p.seller.id = :sellerId " +
-            "AND p.status = :status " +
+            "AND p.startDate <= CURRENT_TIMESTAMP " +
+            "AND p.endDate > CURRENT_TIMESTAMP " +
             "ORDER BY p.startDate DESC")
-    List<Product> findProductsBySellerAndStatus(@Param("sellerId") Long sellerId, @Param("status") ProductStatus status);
+    List<Product> findProductsBySellerAndStatus(@Param("sellerId") Long sellerId);
 }

--- a/src/main/java/com/example/whathis/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/whathis/product/repository/ProductRepository.java
@@ -1,6 +1,10 @@
 package com.example.whathis.product.repository;
 
+import com.example.whathis.common.product.ProductStatus;
 import com.example.whathis.product.entity.Product;
+import com.example.whathis.user.entity.User;
+import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -42,4 +46,11 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
            "WHERE p.seller.id = :sellerId")
     List<Product> findAllMyProducts(@Param("sellerId") Long sellerId);
 
+    // 특정 사용자의 총 누적 판매 금액 조회
+    @Query("SELECT SUM(p.currentAmount) FROM Product p WHERE p.seller.id = :sellerId AND p.status = :status")
+    BigDecimal sumSalesTotalBySellerId(@Param("sellerId") Long sellerId, @Param("status") ProductStatus status);
+
+    // 특정 사용자의 진행 중인 상품 목록 조회
+    @Query("SELECT p FROM Product p JOIN FETCH p.seller LEFT JOIN FETCH p.category WHERE p.seller.id = :sellerId AND p.status = :status ORDER BY p.startDate DESC")
+    List<Product> findProductsBySellerAndStatus(@Param("sellerId") Long sellerId, @Param("status") ProductStatus status);
 }

--- a/src/main/java/com/example/whathis/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/whathis/product/repository/ProductRepository.java
@@ -47,10 +47,17 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findAllMyProducts(@Param("sellerId") Long sellerId);
 
     // 특정 사용자의 총 누적 판매 금액 조회
-    @Query("SELECT SUM(p.currentAmount) FROM Product p WHERE p.seller.id = :sellerId AND p.status = :status")
+    @Query("SELECT SUM(p.currentAmount) " +
+            "FROM Product p " +
+            "WHERE p.seller.id = :sellerId " +
+            "AND p.status = :status")
     BigDecimal sumSalesTotalBySellerId(@Param("sellerId") Long sellerId, @Param("status") ProductStatus status);
 
     // 특정 사용자의 진행 중인 상품 목록 조회
-    @Query("SELECT p FROM Product p JOIN FETCH p.seller LEFT JOIN FETCH p.category WHERE p.seller.id = :sellerId AND p.status = :status ORDER BY p.startDate DESC")
+    @Query("SELECT p " +
+            "FROM Product p JOIN FETCH p.seller LEFT JOIN FETCH p.category " +
+            "WHERE p.seller.id = :sellerId " +
+            "AND p.status = :status " +
+            "ORDER BY p.startDate DESC")
     List<Product> findProductsBySellerAndStatus(@Param("sellerId") Long sellerId, @Param("status") ProductStatus status);
 }

--- a/src/main/java/com/example/whathis/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/whathis/review/repository/ReviewRepository.java
@@ -28,4 +28,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
            "ORDER BY r.createdAt DESC")
     List<Review> findAllByProductIdWithUserAndOrder(@Param("productId") Long productId);
 
+    // 특정 사용자의 판매 상품에 대한 리뷰 평균 별점 조회
+    @Query("SELECT AVG(r.star) FROM Review r WHERE r.product.seller.id = :sellerId")
+    Double findRatingAvgBySellerId(@Param("sellerId") Long sellerId);
 }

--- a/src/main/java/com/example/whathis/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/whathis/review/repository/ReviewRepository.java
@@ -29,6 +29,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findAllByProductIdWithUserAndOrder(@Param("productId") Long productId);
 
     // 특정 사용자의 판매 상품에 대한 리뷰 평균 별점 조회
-    @Query("SELECT AVG(r.star) FROM Review r WHERE r.product.seller.id = :sellerId")
+    @Query("SELECT AVG(r.star) " +
+            "FROM Review r " +
+            "WHERE r.product.seller.id = :sellerId")
     Double findRatingAvgBySellerId(@Param("sellerId") Long sellerId);
 }

--- a/src/main/java/com/example/whathis/user/controller/UserController.java
+++ b/src/main/java/com/example/whathis/user/controller/UserController.java
@@ -7,7 +7,9 @@ import com.example.whathis.auth.dto.request.LoginRequest;
 import com.example.whathis.auth.dto.request.SignupRequest;
 import com.example.whathis.auth.dto.response.TokenResponse;
 import com.example.whathis.config.CustomUserDetails;
+import com.example.whathis.product.dto.response.UserProfileResponse;
 import com.example.whathis.user.dto.response.UserResponse;
+import com.example.whathis.user.entity.User;
 import com.example.whathis.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -57,5 +59,15 @@ public class UserController {
     ) {
         userService.deleteUser(userDetails.getUser());
         return ResponseEntity.ok(ApiResponse.successWithMessage("회원 탈퇴가 완료되었습니다."));
+    }
+
+    @GetMapping("/profile/{sellerId}")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getSellerProfile(
+            @PathVariable Long sellerId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User currentUser = userDetails != null ? userDetails.getUser() : null;
+        UserProfileResponse response = userService.getUserProfile(sellerId, currentUser);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/example/whathis/user/entity/User.java
+++ b/src/main/java/com/example/whathis/user/entity/User.java
@@ -2,12 +2,7 @@ package com.example.whathis.user.entity;
 
 import com.example.whathis.BaseEntity;
 import com.example.whathis.auth.dto.request.UserUpdateRequest;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -47,6 +42,7 @@ public class User extends BaseEntity {
     @Setter
     private String brn;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private AuthProvider provider = AuthProvider.LOCAL;
 

--- a/src/main/java/com/example/whathis/user/service/UserService.java
+++ b/src/main/java/com/example/whathis/user/service/UserService.java
@@ -4,11 +4,17 @@ import com.example.whathis.auth.dto.request.PasswordUpdateRequest;
 import com.example.whathis.auth.dto.request.UserUpdateRequest;
 import com.example.whathis.common.exception.BusinessException;
 import com.example.whathis.common.exception.ErrorCode;
+import com.example.whathis.common.product.ProductStatus;
 import com.example.whathis.config.JwtProvider;
 import com.example.whathis.auth.dto.request.LoginRequest;
 import com.example.whathis.auth.dto.request.SignupRequest;
 import com.example.whathis.auth.dto.response.TokenResponse;
 import com.example.whathis.follow.repository.FollowRepository;
+import com.example.whathis.product.dto.response.ProductResponse;
+import com.example.whathis.product.dto.response.UserProfileResponse;
+import com.example.whathis.product.entity.Product;
+import com.example.whathis.product.repository.ProductRepository;
+import com.example.whathis.review.repository.ReviewRepository;
 import com.example.whathis.user.dto.response.UserResponse;
 import com.example.whathis.user.entity.User;
 import com.example.whathis.user.repository.UserRepository;
@@ -16,6 +22,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +35,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final FollowRepository followRepository;
+    private final ReviewRepository reviewRepository;
+    private final ProductRepository productRepository;
 
     @Transactional(readOnly = true)
     public UserResponse getProfile(User user) {
@@ -79,5 +91,45 @@ public class UserService {
 
         // 진행중인 펀딩이나 주문이 있는지 확인하는 로직은 추후에 추가
         userRepository.delete(currentUser);
+    }
+
+    @Transactional(readOnly = true)
+    public UserProfileResponse getUserProfile(Long sellerId, User currentUser) {
+        // 판매자 존재 여부 확인
+        User seller = userRepository.findById(sellerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        long followerCount = followRepository.countByFollowingId(sellerId);
+
+        // 리뷰가 없으면 0.0, 있으면 소수점 첫째 자리까지 반올림
+        Double ratingAvg = reviewRepository.findRatingAvgBySellerId(sellerId);
+        if(ratingAvg == null) {
+            ratingAvg = 0.0;
+        } else {
+            ratingAvg = Math.round(ratingAvg * 10) / 10.0;
+        }
+
+        // 성공으로 종료된 상품들에 대한 누적 판매 금액
+        BigDecimal salesTotalAmount = productRepository.sumSalesTotalBySellerId(sellerId, ProductStatus.SUCCESS);
+        if(salesTotalAmount == null) {
+            salesTotalAmount = BigDecimal.ZERO;
+        }
+
+        // 진행 중인 상품 목록
+        List<Product> products = productRepository.findProductsBySellerAndStatus(sellerId, ProductStatus.ONGOING);
+        List<ProductResponse> productResponses = products.stream()
+                .map(ProductResponse::from)
+                .collect(Collectors.toList());
+
+        boolean isFollowing = currentUser != null && followRepository.existsByFollowerAndFollowing(currentUser, seller);
+
+        return UserProfileResponse.of(
+                seller,
+                followerCount,
+                ratingAvg,
+                salesTotalAmount,
+                isFollowing,
+                productResponses
+        );
     }
 }

--- a/src/main/java/com/example/whathis/user/service/UserService.java
+++ b/src/main/java/com/example/whathis/user/service/UserService.java
@@ -4,7 +4,6 @@ import com.example.whathis.auth.dto.request.PasswordUpdateRequest;
 import com.example.whathis.auth.dto.request.UserUpdateRequest;
 import com.example.whathis.common.exception.BusinessException;
 import com.example.whathis.common.exception.ErrorCode;
-import com.example.whathis.common.product.ProductStatus;
 import com.example.whathis.config.JwtProvider;
 import com.example.whathis.auth.dto.request.LoginRequest;
 import com.example.whathis.auth.dto.request.SignupRequest;
@@ -110,13 +109,13 @@ public class UserService {
         }
 
         // 성공으로 종료된 상품들에 대한 누적 판매 금액
-        BigDecimal salesTotalAmount = productRepository.sumSalesTotalBySellerId(sellerId, ProductStatus.SUCCESS);
+        BigDecimal salesTotalAmount = productRepository.sumSalesTotalBySellerId(sellerId);
         if(salesTotalAmount == null) {
             salesTotalAmount = BigDecimal.ZERO;
         }
 
         // 진행 중인 상품 목록
-        List<Product> products = productRepository.findProductsBySellerAndStatus(sellerId, ProductStatus.ONGOING);
+        List<Product> products = productRepository.findProductsBySellerAndStatus(sellerId);
         List<ProductResponse> productResponses = products.stream()
                 .map(ProductResponse::from)
                 .collect(Collectors.toList());


### PR DESCRIPTION
사용자가 로그인 여부와 상관없이 판매자의 상세 프로필과 판매 중인 상품 목록을 조회할 수 있도록 작성했습니다.

## 작업 내용
- `ProductRepository`, `ReviewRepository` 쿼리 메서드 추가 작성
    - 누적 판매 금액: 진행 중인 상품과 성공으로 종료된 상품의 누적 판매 금액으로 하게 되면 진행 중인 상품이 실패로 끝났을 경우 누적 판매 금액이 감소하여 사용자에게 신뢰도를 잃을 수 있다고 판단하여 성공으로 끝난 상품의 금액만 포함하였습니다.
    - 평균 별점: 판매자의 모든 상품 리뷰 평점에 대한 평균값 조회
    - 상품 목록: 현재 진행 중인 상품 목록을 최신순으로 조회
- `UserService` 판매자 프로필 로직 작성
    - 평점이나 판매 이력이 없는 판매자의 경우 기본값을 0으로 설정했습니다.
    - 평균 별점은 소수점 첫째 자리까지 반올림하도록 작성했습니다.
    - 로그인 여부에 따라 isFollowing 값을 판단하도록 작성했습니다.
- `UserController`: 특정 판매자의 프로필을 조회하는 API를 작성
- `SecurityConfig`: 판매자 프로필은 로그인 여부에 상관없이 조회가 가능해야 하므로 접근 권한 허용했습니다.

## 추가 수정 사항
- `ProductRepository`, `UserService`: `ProductStatus`의 삭제로 인해 쿼리문을 수정하였습니다.
    - 총 누적 판매 금액에는 성공으로 종료된 상품의 판매 금액만 포함되어야 하므로 현재 모금액이 목표 모금액 이상이며 종료일이 현재보다 과거인 상품의 누적 상품 금액을 구하도록 작성했습니다.
    - 진행중인 상품 목록 조회에서는 시작일이 현재보다 과거이면서 종료일은 지나지 않은 상품들을 조회하도록 작성했습니다.

## 테스트
**[비로그인 상태로 프로필 조회]**
로그인하지 않은 상태에서 1번 사용자의 프로필을 조회한 결과입니다.
사용자 정보에서 1번 사용자의 정보를 확인할 수 있고, 1번 사용자를 아무도 팔로우하지 않은 상태이므로 팔로워 수는 0, 1번 사용자의 상품이 모두 ONGOING(진행) 상태이므로 평균 별점과 누적 판매 금액은 모두 0으로 조회됩니다.
로그인하지 않은 상태이므로 following 상태는 false입니다.
<img width="1397" height="876" alt="not login get profile" src="https://github.com/user-attachments/assets/32e61f28-e8f2-47b3-b8fe-d05e0fe7302a" />

**[로그인 상태로 프로필 조회]**
로그인한 상태에서 1번 사용자를 팔로우하고 1번 사용자의 프로필을 조회한 결과입니다.
followerCount가 1, following 상태가 true로 조회됩니다.
<img width="1395" height="872" alt="login and follow get profile" src="https://github.com/user-attachments/assets/8f9230be-b04c-438b-a741-5be259e8aad4" />

**[종료된 상품 / 리뷰가 있는 경우에서 프로필 조회]**
data.sql에 등록된 2번 상품의 상태를 SUCCESS로 변경하고, 별점이 각 5점, 4점, 5점인 리뷰 3개를 등록한 뒤 1번 사용자의 프로필을 조회한 결과입니다.
ratingAvg(평균 별점)이 4.7, salesTotalAmount가 4200000.00으로 조회됩니다.
<img width="1392" height="873" alt="get profile" src="https://github.com/user-attachments/assets/1420f2f2-4825-4074-8fa9-a69ece850002" />

Close #39 