### PR TITLE
feat/Order: 주문 및 포트원 결제 시스템 연동 구현

### DIFF
--- a/src/main/java/com/example/whathis/order/controller/OrderController.java
+++ b/src/main/java/com/example/whathis/order/controller/OrderController.java
@@ -10,10 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,5 +28,13 @@ public class OrderController {
     ) {
         OrderCreateResponse response = orderService.createOrder(userDetails.getUser(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<List<OrderCreateResponse>>> getMyOrders(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        List<OrderCreateResponse> responses = orderService.getOrderByUser(userDetails.getUser());
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responses));
     }
 }

--- a/src/main/java/com/example/whathis/order/controller/OrderController.java
+++ b/src/main/java/com/example/whathis/order/controller/OrderController.java
@@ -1,7 +1,17 @@
 package com.example.whathis.order.controller;
 
+import com.example.whathis.common.response.ApiResponse;
+import com.example.whathis.config.CustomUserDetails;
+import com.example.whathis.order.dto.request.OrderCreateRequest;
+import com.example.whathis.order.dto.response.OrderCreateResponse;
 import com.example.whathis.order.service.OrderService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,4 +22,12 @@ public class OrderController {
 
     private final OrderService orderService;
 
+    @PostMapping
+    public ResponseEntity<ApiResponse<OrderCreateResponse>> createOrder(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody OrderCreateRequest request
+    ) {
+        OrderCreateResponse response = orderService.createOrder(userDetails.getUser(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
 }

--- a/src/main/java/com/example/whathis/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/example/whathis/order/dto/request/OrderCreateRequest.java
@@ -1,0 +1,30 @@
+package com.example.whathis.order.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OrderCreateRequest {
+
+    @NotNull(message = "상품 ID는 필수입니다")
+    private Long productId;
+
+    @NotNull(message = "상품 수량은 필수입니다")
+    private Integer quantity;
+
+    // 배송 정보
+    @NotBlank(message = "수령인 이름은 필수입니다.")
+    private String receiverName;
+
+    @NotBlank(message = "수령인 연락처는 필수입니다.")
+    private String receiverPhone;
+
+    @NotBlank(message = "주소는 필수입니다.")
+    private String receiverAddress;
+
+    private String requestNote;
+
+}

--- a/src/main/java/com/example/whathis/order/dto/response/OrderCreateResponse.java
+++ b/src/main/java/com/example/whathis/order/dto/response/OrderCreateResponse.java
@@ -1,0 +1,36 @@
+package com.example.whathis.order.dto.response;
+
+import com.example.whathis.order.entity.Order;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class OrderCreateResponse {
+    private Long orderId;
+    private String merchantUid; // 주문 번호
+    private String productName;
+    private BigDecimal amount;
+    private String receiverName;
+    private String receiverPhone;
+    private String receiverAddress;
+    private String requestNote;
+
+    public static OrderCreateResponse from(Order order) {
+        return OrderCreateResponse.builder()
+                .orderId(order.getId())
+                .merchantUid(order.getOrderNumber())
+                .productName(order.getProduct().getTitle())
+                .amount(order.getTotalAmount())
+                .receiverName(order.getReceiverName())
+                .receiverPhone(order.getReceiverPhone())
+                .receiverAddress(order.getReceiverAddress())
+                .requestNote(order.getRequest())
+                .build();
+
+
+    }
+}

--- a/src/main/java/com/example/whathis/order/entity/Order.java
+++ b/src/main/java/com/example/whathis/order/entity/Order.java
@@ -82,10 +82,23 @@ public class Order extends BaseEntity {
         }
     }
 
+    @Column(nullable = false)
+    private String receiverName;
+
+    @Column(nullable = false)
+    private String receiverPhone;
+
+    @Column(nullable = false)
+    private String receiverAddress;
+
+    @Column
+    private String request;
+
     @Builder
     public Order(
         User buyer, Product product, Integer quantity, BigDecimal totalAmount,
-        OrderStatus status, LocalDateTime reservedPaymentDate, LocalDateTime confirmedAt
+        OrderStatus status, LocalDateTime reservedPaymentDate, LocalDateTime confirmedAt,
+        String  receiverName, String receiverPhone, String receiverAddress, String request
     ) {
         this.buyer = buyer;
         this.product = product;
@@ -94,6 +107,15 @@ public class Order extends BaseEntity {
         this.status = status != null ? status : OrderStatus.PENDING;
         this.reservedPaymentDate = reservedPaymentDate;
         this.confirmedAt = confirmedAt;
+        this.receiverName = receiverName;
+        this.receiverPhone = receiverPhone;
+        this.receiverAddress = receiverAddress;
+        this.request = request;
     }
 
+    // 주문 상태 예약으로 변경
+    public void confirmOrder() {
+        this.status = OrderStatus.RESERVED; // 펀딩은 '예약' 상태가 됨
+        this.confirmedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/example/whathis/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/whathis/order/repository/OrderRepository.java
@@ -1,12 +1,16 @@
 package com.example.whathis.order.repository;
 
 import com.example.whathis.order.entity.Order;
+import com.example.whathis.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByOrderNumber(String orderNumber);
+
+    List<Order> findAllByBuyerOrderByIdDesc(User buyer);
 }

--- a/src/main/java/com/example/whathis/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/whathis/order/repository/OrderRepository.java
@@ -4,7 +4,9 @@ import com.example.whathis.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
-
+    Optional<Order> findByOrderNumber(String orderNumber);
 }

--- a/src/main/java/com/example/whathis/order/service/OrderService.java
+++ b/src/main/java/com/example/whathis/order/service/OrderService.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -53,5 +55,14 @@ public class OrderService {
         orderRepository.save(order);
 
         return OrderCreateResponse.from(order);
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrderCreateResponse> getOrderByUser(User buyer) {
+        List<Order> orders = orderRepository.findAllByBuyerOrderByIdDesc(buyer);
+
+        return orders.stream()
+                .map(OrderCreateResponse::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/whathis/order/service/OrderService.java
+++ b/src/main/java/com/example/whathis/order/service/OrderService.java
@@ -1,13 +1,57 @@
 package com.example.whathis.order.service;
 
+import com.example.whathis.common.exception.BusinessException;
+import com.example.whathis.common.exception.ErrorCode;
+import com.example.whathis.common.order.OrderStatus;
+import com.example.whathis.order.dto.request.OrderCreateRequest;
+import com.example.whathis.order.dto.response.OrderCreateResponse;
+import com.example.whathis.order.entity.Order;
 import com.example.whathis.order.repository.OrderRepository;
+import com.example.whathis.product.entity.Product;
+import com.example.whathis.product.repository.ProductRepository;
+import com.example.whathis.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class OrderService {
 
     private final OrderRepository orderRepository;
+    private final ProductRepository productRepository;
 
+    public OrderCreateResponse createOrder(User buyer, OrderCreateRequest request) {
+        // 상품 조회
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // 재고 확인
+        if (!product.hasStock(request.getQuantity())) {
+            throw new BusinessException(ErrorCode.OUT_OF_STOCK);
+        }
+
+        // 결제 금액 (quantity는 int라서 BigDecimal로 변환 후 계산)
+        BigDecimal totalAmount = product.getPrice().multiply(BigDecimal.valueOf(request.getQuantity()));
+
+        // PENDING(결제 대기) 상태 주문 생성
+        Order order = Order.builder()
+                .buyer(buyer)
+                .product(product)
+                .quantity(request.getQuantity())
+                .totalAmount(totalAmount)
+                .receiverName(request.getReceiverName())
+                .receiverPhone(request.getReceiverPhone())
+                .receiverAddress(request.getReceiverAddress())
+                .request(request.getRequestNote())
+                .status(OrderStatus.PENDING)
+                .build();
+
+        orderRepository.save(order);
+
+        return OrderCreateResponse.from(order);
+    }
 }

--- a/src/main/java/com/example/whathis/payment/controller/PaymentController.java
+++ b/src/main/java/com/example/whathis/payment/controller/PaymentController.java
@@ -1,7 +1,14 @@
 package com.example.whathis.payment.controller;
 
+import com.example.whathis.common.response.ApiResponse;
+import com.example.whathis.config.CustomUserDetails;
+import com.example.whathis.payment.dto.request.PaymentCompleteRequest;
 import com.example.whathis.payment.service.PaymentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,4 +19,12 @@ public class PaymentController {
 
     private final PaymentService paymentService;
 
+    @PostMapping("/complete")
+    public ResponseEntity<ApiResponse<Void>> completePayment(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody PaymentCompleteRequest request
+    ) {
+        paymentService.verifyAndCompletePayment(userDetails.getUser(), request);
+        return ResponseEntity.ok(ApiResponse.successWithMessage("결제가 성공적으로 완료되었습니다."));
+    }
 }

--- a/src/main/java/com/example/whathis/payment/dto/request/PaymentCompleteRequest.java
+++ b/src/main/java/com/example/whathis/payment/dto/request/PaymentCompleteRequest.java
@@ -1,0 +1,10 @@
+package com.example.whathis.payment.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PaymentCompleteRequest {
+    private String paymentId;
+}

--- a/src/main/java/com/example/whathis/payment/entity/Payment.java
+++ b/src/main/java/com/example/whathis/payment/entity/Payment.java
@@ -24,8 +24,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
+
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
 
 @Entity
 @Getter
@@ -94,4 +97,26 @@ public class Payment extends BaseEntity {
             + "-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
     }
 
+    @Builder
+    private Payment(
+            Order order,
+            User user,
+            BigDecimal amount,
+            PaymentMethod method,
+            PaymentStatus status,
+            PaymentType type,
+            String pgProvider,
+            String pgTransactionId,
+            LocalDateTime paidAt
+    ) {
+        this.order = order;
+        this.user = user;
+        this.amount = amount;
+        this.method = method;
+        this.status = status;
+        this.type = type;
+        this.pgProvider = pgProvider;
+        this.pgTransactionId = pgTransactionId;
+        this.paidAt = paidAt;
+    }
 }

--- a/src/main/java/com/example/whathis/payment/service/PaymentService.java
+++ b/src/main/java/com/example/whathis/payment/service/PaymentService.java
@@ -1,13 +1,91 @@
 package com.example.whathis.payment.service;
 
+import com.example.whathis.common.exception.BusinessException;
+import com.example.whathis.common.exception.ErrorCode;
+import com.example.whathis.common.payment.PaymentMethod;
+import com.example.whathis.common.payment.PaymentStatus;
+import com.example.whathis.common.payment.PaymentType;
+import com.example.whathis.order.entity.Order;
+import com.example.whathis.order.repository.OrderRepository;
+import com.example.whathis.payment.dto.request.PaymentCompleteRequest;
+import com.example.whathis.payment.entity.Payment;
 import com.example.whathis.payment.repository.PaymentRepository;
+import com.example.whathis.user.entity.User;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+    private final WebClient webClient = WebClient.create("https://api.portone.io"); // V2 API 주소
+
+    @Value("${portone.api-secret}")
+    private String apiSecret;
+
+    // 결제 검증 및 완료 처리
+    public void verifyAndCompletePayment(User user, PaymentCompleteRequest request) {
+        String paymentId = request.getPaymentId();
+
+        // 포트원 결제내역 조회
+        // 토큰 발급 없이 Secret Key를 헤더에 바로 사용
+        JsonNode paymentResponse = webClient.get()
+                .uri("/payments/" + paymentId)
+                .header("Authorization", "PortOne " + apiSecret)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+
+        if (paymentResponse == null || paymentResponse.has("code")) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "결제 정보 조회 실패");
+        }
+
+        // V2 응답 구조: { "id": "...", "status": "PAID", "amount": { "total": 1000, ... }, ... }
+        JsonNode paymentData = paymentResponse;
+
+        // 주문 조회 (paymentId = merchantUid = orderNumber)
+        Order order = orderRepository.findByOrderNumber(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        // 결제 금액 검증
+        BigDecimal paidAmount = new BigDecimal(paymentData.get("amount").get("total").asText());
+        if (order.getTotalAmount().compareTo(paidAmount) != 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "결제 금액 불일치");
+        }
+
+        // 결제 상태 검증
+        String status = paymentData.get("status").asText();
+        if (!"PAID".equals(status)) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "결제가 완료되지 않았습니다.");
+        }
+
+        // 주문 상태 변경 및 저장
+        order.confirmOrder();
+        order.getProduct().decreaseInventory(order.getQuantity());
+
+        Payment payment = Payment.builder()
+                .order(order)
+                .user(user)
+                .amount(paidAmount)
+                .method(PaymentMethod.CREDIT_CARD) // V2 응답에서 method 파싱 필요
+                .status(PaymentStatus.APPROVED)
+                .type(PaymentType.RESERVED)
+                .pgProvider("PORTONE_V2")
+                .pgTransactionId(paymentData.get("id").asText()) // paymentId
+                .paidAt(LocalDateTime.now())
+                .build();
+
+        paymentRepository.save(payment);
+    }
 
 }

--- a/src/main/java/com/example/whathis/product/entity/Product.java
+++ b/src/main/java/com/example/whathis/product/entity/Product.java
@@ -206,6 +206,10 @@ public class Product extends BaseEntity {
             throw new IllegalStateException("재고가 부족합니다. 남은 재고: " + this.inventory);
         }
         this.inventory -= quantity;
+        // 펀딩 모금액 증가
+        this.currentAmount = this.currentAmount.add(
+                this.price.multiply(BigDecimal.valueOf(quantity))
+        );
     }
 
     // 재고 증가 (펀딩 취소 시)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,4 +45,7 @@ oauth:
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
 
+# PortOne 설정
+portone:
+  api-secret: ${PORTONE_API_SECRET}
 


### PR DESCRIPTION
## 작업 내용
포트원(PortOne) V2 API를 연동하여 상품 주문부터 결제 검증, 주문 조회까지 이어지는 결제 프로세스를 작성했습니다.

### 주문 생성
- 포트원에 주문 번호를 전달해야 결제 진행이 가능하여 결제 전 주문 정보를 PENDING 상태로 데이터베이스에 저장하고, 주문 번호를 생성합니다.
- 생성한 주문 번호를 포트원에 전달하여 결제 요청을 합니다.

### 결제 검증 및 완료
- 결제창이 호출되면 사용자가 결제를 진행합니다.
- 결제가 완료되면 서버에서 결제 검증을 진행합니다.
    - 포트원 서버에서 실제 결제 내역을 조회하고, 주문 금액과 실제 결제 금액이 일치하는지 확인합니다.
    - 결제 상태를 확인하고 검증 통과시 재고 감소/달성 금액 증가/주문 상태 변경(RESERVED) 로직이 수행됩니다.

### 주문 내역 조회
- 사용자가 주문 내역을 조회할 수 있습니다.

## 테스트
[주문 수량 선택 후 펀딩하기]
주문 수량을 선택한뒤 펀딩하기를 클릭하면 주문서 페이지로 이동합니다.
<img width="1918" height="962" alt="image" src="https://github.com/user-attachments/assets/e6bedf22-e5ea-417a-9aca-59f6303b1518" />

[주문서 입력 후 계산하기]
주문서에서는 수령인 이름, 전화번호, 주소가 필수 입력사항이며 배송 요청사항은 선택사항입니다.
<img width="1918" height="963" alt="image" src="https://github.com/user-attachments/assets/cea4d429-4abf-4d3d-b09b-60bdf1a2cd3d" />

[결제 진행]
결제 유형을 선택한뒤 결제를 진행합니다.
<img width="1918" height="955" alt="image" src="https://github.com/user-attachments/assets/4346db7d-8773-4e93-ae0d-71269728b283" />
<img width="1918" height="958" alt="image" src="https://github.com/user-attachments/assets/f4f5a550-2ce8-4673-895c-a969cdabaafd" />

[결제 완료]
결제 성공 시 주문이 완료됩니다.
<img width="1918" height="952" alt="image" src="https://github.com/user-attachments/assets/c415b86e-9f37-4dab-8913-68a616619416" />

[주문 내역 조회]
사용자가 주문 내역을 조회할 수 있습니다.
<img width="1382" height="872" alt="image" src="https://github.com/user-attachments/assets/b66c41a5-b484-42d8-a7a3-4fe207016ad1" />

### 참고사항
- 포트원 환경 변수 설정
`application.yml`에 환경 변수가 추가되었습니다.
환경 변수를 등록해주셔야 실행이 가능합니다.
- order, payment 브랜치 분리 불가
주문과 결제가 하나의 프로세스로 진행되어 분리하지 못하고 feat/order 브랜치에 통합하였습니다.

Close #47 