### PR TITLE
fix : Review 파트 수정(펀딩하지 않아도 리뷰 작성 가능)

### DIFF
--- a/src/main/java/com/example/whathis/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/whathis/common/exception/ErrorCode.java
@@ -46,10 +46,10 @@ public enum ErrorCode {
     ALREADY_FOLLOWING("ALREADY_FOLLOWING", "이미 팔로우 중입니다"),
     NOT_FOLLOWING("NOT_FOLLOWING", "팔로우하지 않은 사용자입니다"),
     OUT_OF_STOCK("OUT_OF_STOCK", "재고가 부족합니다"),
-    ALREADY_REVIEWED("ALREADY_REVIEWED", "이미 리뷰를 작성한 주문입니다"),
+    ALREADY_REVIEWED("ALREADY_REVIEWED", "이미 이 상품에 대해 기대평을 작성하셨습니다."),
     
     // 422 Unprocessable Entity
-    FUNDING_NOT_ONGOING("FUNDING_NOT_ONGOING", "펀딩이 진행 중이 아닙니다"),
+    FUNDING_NOT_ONGOING("FUNDING_NOT_ONGOING", "기대평은 펀딩 기간 내에만 작성 가능합니다."),
     FUNDING_ENDED("FUNDING_ENDED", "펀딩이 종료되었습니다"),
     INVALID_ORDER_STATUS("INVALID_ORDER_STATUS", "주문 상태가 올바르지 않습니다"),
     CANNOT_CANCEL_ORDER("CANNOT_CANCEL_ORDER", "주문을 취소할 수 없습니다"),

--- a/src/main/java/com/example/whathis/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/example/whathis/review/dto/request/ReviewCreateRequest.java
@@ -15,13 +15,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ReviewCreateRequest {
 
-    @NotNull(message = "주문 ID는 필수입니다.")
-    private Long orderId;
-
-    @Pattern(
-        regexp = "^(https?://.*\\.(png|jpg|jpeg|webp))$",
-        message = "이미지 URL(jpg, jpeg, png, webp) 형식이어야 합니다."
-    )
+    @Pattern(regexp = "^(https?://.*\\.(png|jpg|jpeg|webp))$", message = "이미지 URL(jpg, jpeg, png, webp) 형식이어야 합니다.")
     private String imageUrls;
 
     @NotBlank(message = "리뷰 내용은 필수입니다.")
@@ -29,7 +23,8 @@ public class ReviewCreateRequest {
     private String content;
 
     @NotNull(message = "평점은 필수입니다.")
-    @Min(1) @Max(5)
+    @Min(1)
+    @Max(5)
     private Integer star;
 
 }

--- a/src/main/java/com/example/whathis/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/example/whathis/review/dto/response/ReviewResponse.java
@@ -25,12 +25,9 @@ public class ReviewResponse {
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
-    
+
     // 작성자 정보
     private ReviewerInfo reviewer;
-
-    // 주문 정보
-    private OrderInfo order;
 
     // 정적 중첩 클래스 - 중요 정보 보호를 위함
     // 시작
@@ -42,12 +39,6 @@ public class ReviewResponse {
         private String profileImageUrl;
     }
 
-    @Getter
-    @Builder
-    public static class OrderInfo {
-        private Long id;
-        private String orderNumber;
-    }
     // 끝
 
     public static ReviewResponse from(Review review) {
@@ -60,17 +51,12 @@ public class ReviewResponse {
                 .createdAt(review.getCreatedAt())
                 .updatedAt(review.getUpdatedAt())
                 .reviewer(ReviewerInfo.builder()
-                    .id(review.getUser().getId())
-                    .nickname(review.getUser().getNickname())
-                    .profileImageUrl(review.getUser().getProfileImageUrl())
-                    .build())
-                .order(review.getOrder() != null ? OrderInfo.builder()
-                    .id(review.getOrder().getId())
-                    .orderNumber(review.getOrder().getOrderNumber())
-                    .build() : null)
+                        .id(review.getUser().getId())
+                        .nickname(review.getUser().getNickname())
+                        .profileImageUrl(review.getUser().getProfileImageUrl())
+                        .build())
                 .build();
     }
-
 
     // JSON 배열 형태의 이미지 URL 문자열을 List로 파싱
     // ex) "["url1", "url2"]" -> ["url1", "url2"]
@@ -78,18 +64,18 @@ public class ReviewResponse {
         if (imageUrlsJson == null || imageUrlsJson.isBlank()) {
             return Collections.emptyList();
         }
-        
+
         // 간단한 파싱(실제로는 Jackson 사용)
         String cleaned = imageUrlsJson
-            .replace("[", "")
-            .replace("]", "")
-            .replace("\"", "")
-            .trim();
-        
+                .replace("[", "")
+                .replace("]", "")
+                .replace("\"", "")
+                .trim();
+
         if (cleaned.isEmpty()) {
             return Collections.emptyList();
         }
-        
+
         return Arrays.asList(cleaned.split(",\\s*"));
     }
 

--- a/src/main/java/com/example/whathis/review/entity/Review.java
+++ b/src/main/java/com/example/whathis/review/entity/Review.java
@@ -1,7 +1,6 @@
 package com.example.whathis.review.entity;
 
 import com.example.whathis.BaseEntity;
-import com.example.whathis.order.entity.Order;
 import com.example.whathis.product.entity.Product;
 import com.example.whathis.review.dto.request.ReviewCreateRequest;
 import com.example.whathis.user.entity.User;
@@ -13,7 +12,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -52,15 +50,6 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
-    // 주문 정보 (구매 확정 후 작성 가능)
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_id")
-    private Order order;
-
-    // 주문 번호 (검색 최적화 및 히스토리용)
-    @Column(nullable = false)
-    private String orderNumber;
-
     // 리뷰 이미지 (여러 장 가능, 간단히 JSON 배열 문자열로 저장)
     @Column(columnDefinition = "TEXT")
     private String imageUrls; // ["url1", "url2", ...] 형태
@@ -73,29 +62,24 @@ public class Review extends BaseEntity {
     private Review(
             String content, Integer star,
             User user, Product product,
-            Order order, String imageUrls,
-            String orderNumber) {
+            String imageUrls) {
         this.content = content;
         this.star = star;
         this.user = user;
         this.product = product;
-        this.order = order;
         this.imageUrls = imageUrls;
         this.helpfulCount = 0;
-        this.orderNumber = orderNumber;
     }
 
     public static Review of(
             ReviewCreateRequest request, User user,
-            Product product, Order order) {
+            Product product) {
         return Review.builder()
                 .content(request.getContent())
                 .star(request.getStar())
                 .imageUrls(request.getImageUrls())
                 .user(user)
                 .product(product)
-                .order(order)
-                .orderNumber(order.getOrderNumber())
                 .build();
     }
 

--- a/src/main/java/com/example/whathis/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/whathis/review/repository/ReviewRepository.java
@@ -10,22 +10,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    // 해당 주문에 이미 리뷰가 작성되었는지 확인
-    // 특정 ID의 주문(orderId)에 대한 리뷰(r)가 하나(COUNT(r) > 0)라도 있으면 true 반환
-    @Query("""
-        SELECT CASE WHEN COUNT(r) > 0 THEN true ELSE false END
-        FROM Review r
-        WHERE r.order.id = :orderId
-        """)
-    boolean existsByOrderId(@Param("orderId") Long orderId);
+    // 사용자가 해당 상품에 이미 리뷰를 작성했는지 확인
+    boolean existsByProductIdAndUserId(Long productId, Long userId);
 
     // 특정 상품의 모든 리뷰 조회
     // N+1 방지를 위한 fetch join
     @Query("SELECT r FROM Review r " +
-           "JOIN FETCH r.user " +
-           "LEFT JOIN FETCH r.order " +
-           "WHERE r.product.id = :productId " +
-           "ORDER BY r.createdAt DESC")
+            "JOIN FETCH r.user " +
+            "WHERE r.product.id = :productId " +
+            "ORDER BY r.createdAt DESC")
     List<Review> findAllByProductIdWithUserAndOrder(@Param("productId") Long productId);
 
     // 특정 사용자의 판매 상품에 대한 리뷰 평균 별점 조회

--- a/src/main/java/com/example/whathis/review/service/ReviewService.java
+++ b/src/main/java/com/example/whathis/review/service/ReviewService.java
@@ -2,9 +2,6 @@ package com.example.whathis.review.service;
 
 import com.example.whathis.common.exception.BusinessException;
 import com.example.whathis.common.exception.ErrorCode;
-import com.example.whathis.common.order.OrderStatus;
-import com.example.whathis.order.entity.Order;
-import com.example.whathis.order.repository.OrderRepository;
 import com.example.whathis.product.entity.Product;
 import com.example.whathis.product.repository.ProductRepository;
 import com.example.whathis.review.dto.request.ReviewCreateRequest;
@@ -13,10 +10,12 @@ import com.example.whathis.review.dto.response.ReviewResponse;
 import com.example.whathis.review.entity.Review;
 import com.example.whathis.review.repository.ReviewRepository;
 import com.example.whathis.user.entity.User;
-import java.util.List;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.example.whathis.user.repository.UserRepository;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -24,47 +23,38 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewService {
 
     private final ProductRepository productRepository;
-    private final OrderRepository orderRepository;
     private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
 
     public ReviewResponse save(
         Long productId, User currentUser, ReviewCreateRequest request
     ) {
-        // 로그인 체크
+        // 1. 로그인 체크
         if (currentUser == null) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
         }
+
+        // 유저 정보 재조회 (영속성 컨텍스트 관리)
+        User foundUser = userRepository.findById(currentUser.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         // 2. Product 존재 확인
         Product foundProduct = productRepository.findById(productId)
             .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
-        // 3. Order 존재 확인
-        Order foundOrder = orderRepository.findById(request.getOrderId())
-            .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-
-        // 4. 본인의 주문인지 확인
-        if (!foundOrder.getBuyer().getId().equals(currentUser.getId())) {
-            throw new BusinessException(ErrorCode.NOT_YOUR_ORDER);
+        // 3. 기대평 작성 신청 기간 확인 (펀딩 기간 내에만 가능)
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isBefore(foundProduct.getStartDate()) || now.isAfter(foundProduct.getEndDate())) {
+            throw new BusinessException(ErrorCode.FUNDING_NOT_ONGOING);
         }
 
-        // 5. 주문한 상품이 맞는지 확인
-        if (!foundOrder.getProduct().getId().equals(foundProduct.getId())) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
-        }
-
-        // 6. 주문이 확정된 상태인지 확인 (리뷰 작성 가능 상태)
-        if (foundOrder.getStatus() != OrderStatus.CONFIRMED) {
-            throw new BusinessException(ErrorCode.ORDER_NOT_CONFIRMED);
-        }
-
-        // 7. 이미 리뷰를 작성했는지 확인 (한 주문당 하나의 리뷰만 가능)
-        if (reviewRepository.existsByOrderId(request.getOrderId())) {
+        // 4. 이미 리뷰를 작성했는지 확인 (상품 당 하나의 리뷰만 가능)
+        if (reviewRepository.existsByProductIdAndUserId(productId, foundUser.getId())) {
             throw new BusinessException(ErrorCode.ALREADY_REVIEWED);
         }
 
-        // 8. Review 생성 및 저장
-        Review review = Review.of(request, currentUser, foundProduct, foundOrder);
+        // 5. Review 생성 및 저장
+        Review review = Review.of(request, foundUser, foundProduct);
         Review savedReview = reviewRepository.save(review);
 
         return ReviewResponse.from(savedReview);


### PR DESCRIPTION
## 펀딩(결제)에 참여하지 않아도 리뷰(기대평)를 작성할 수 있도록 수정

### [ 변경 사항 ]

- 리뷰가 아닌 **기대평**이라는 개념으로 변경.

- `Review` 도메인 내의 `Order` 도메인에 대한 의존성 제거.

<br>

### [ Postman 테스트 화면 ]

**1. 펀딩하지 않는 제품에 리뷰 생성 - 성공**
<img width="1004" height="633" alt="스크린샷 2026-01-06 오후 1 45 15" src="https://github.com/user-attachments/assets/bb4b4df8-cb9e-4261-8933-e939c0b29be7" />

<br>**2. 이미 기대평을 작성한 제품에 한 번 더 작성 - 실패(정상)**
<img width="1002" height="422" alt="스크린샷 2026-01-06 오후 1 45 36" src="https://github.com/user-attachments/assets/44e631c9-761e-4646-9346-4387db10a45a" />

<br>**3. 펀딩을 시작하지 않은 제품에 기대평 작성 - 실패(정상)**
<img width="1002" height="419" alt="스크린샷 2026-01-06 오후 1 46 19" src="https://github.com/user-attachments/assets/aa4a91e4-e7d7-4a4a-97cc-3017b4f7e825" />


<br>
<br>

Closes #55