### PR TITLE
feat/Product : 유저가 좋아요한 제품만 조회하는 기능 작성

### DIFF
--- a/src/main/java/com/example/whathis/product/controller/ProductController.java
+++ b/src/main/java/com/example/whathis/product/controller/ProductController.java
@@ -122,4 +122,13 @@ public class ProductController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    // 유저의 좋아요 제품만 조회
+    @GetMapping("/like")
+    public ResponseEntity<ApiResponse<List<ProductResponse>>> getMyLikeProducts(
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        User currentUser = userDetails != null ? userDetails.getUser() : null;
+        List<ProductResponse> response = productLikeService.getLikedProducts(currentUser);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
 }

--- a/src/main/java/com/example/whathis/productlike/repository/ProductLikeRepository.java
+++ b/src/main/java/com/example/whathis/productlike/repository/ProductLikeRepository.java
@@ -1,6 +1,7 @@
 package com.example.whathis.productlike.repository;
 
 import com.example.whathis.productlike.entity.ProductLike;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -16,5 +17,8 @@ public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> 
 
     // 사용자의 특정 상품 좋아요 조회
     Optional<ProductLike> findByUserIdAndProductId(Long userId, Long productId);
+
+    // 사용자가 좋아요를 누른 모든 상품 조회
+    List<ProductLike> findAllByUserId(Long userId);
 
 }

--- a/src/main/java/com/example/whathis/productlike/service/ProductLikeService.java
+++ b/src/main/java/com/example/whathis/productlike/service/ProductLikeService.java
@@ -3,12 +3,15 @@ package com.example.whathis.productlike.service;
 import com.example.whathis.common.exception.BusinessException;
 import com.example.whathis.common.exception.ErrorCode;
 import com.example.whathis.product.dto.response.ProductDetailResponse;
+import com.example.whathis.product.dto.response.ProductResponse;
 import com.example.whathis.product.entity.Product;
 import com.example.whathis.product.repository.ProductRepository;
 import com.example.whathis.product.service.ProductService;
 import com.example.whathis.productlike.entity.ProductLike;
 import com.example.whathis.productlike.repository.ProductLikeRepository;
 import com.example.whathis.user.entity.User;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -79,6 +82,23 @@ public class ProductLikeService {
 
         // 최신 상품 정보(좋아요 수, isLiked 포함) 반환 (조회수 증가 없이)
         return productService.getDetail(productId, currentUser);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProductResponse> getLikedProducts(User currentUser) {
+        // 로그인 체크
+        if (currentUser == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        // 사용자가 좋아요를 누른 모든 ProductLike 조회
+        List<ProductLike> productLikes = productLikeRepository.findAllByUserId(currentUser.getId());
+
+        // ProductLike에서 Product를 추출하여 ProductResponse로 변환
+        return productLikes.stream()
+                .map(ProductLike::getProduct)
+                .map(ProductResponse::from)
+                .collect(Collectors.toList());
     }
 
 }


### PR DESCRIPTION
## 유저가 좋아요를 누른 제품만 조회하는 기능

### [ 변경 사항 ]

- `ProductController.java`
   - `getMyLikeProducts()` 메서드 추가.

- `ProductLikeService.java`
   - `findAllByUserId()` 메서드 추가.

- `ProductLikeRepository.java`
   - `getLikedProducts()` 메서드 추가.

<br>

### [ 테스트 결과 ]

**1. 좋아요를 누른 화면**

<img width="1272" height="479" alt="스크린샷 2026-01-06 오후 5 08 55" src="https://github.com/user-attachments/assets/c4237789-ac5b-4bb6-8c03-a6c5f31dcf52" />


<br>**2. Postman을 통한 조회**

<img width="1001" height="738" alt="스크린샷 2026-01-06 오후 5 02 30" src="https://github.com/user-attachments/assets/8fe101dc-5357-4591-8d11-6322dd7b7668" />
<img width="997" height="182" alt="스크린샷 2026-01-06 오후 5 02 40" src="https://github.com/user-attachments/assets/e3563214-cf6e-444c-a84c-1aea7b0d510d" />



<br>
<br>

Closes #57 