### PR TITLE
feat/Order-detail: 주문 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/whathis/order/controller/OrderController.java
+++ b/src/main/java/com/example/whathis/order/controller/OrderController.java
@@ -4,6 +4,7 @@ import com.example.whathis.common.response.ApiResponse;
 import com.example.whathis.config.CustomUserDetails;
 import com.example.whathis.order.dto.request.OrderCreateRequest;
 import com.example.whathis.order.dto.response.OrderCreateResponse;
+import com.example.whathis.order.dto.response.OrderResponse;
 import com.example.whathis.order.service.OrderService;
 import com.example.whathis.payment.dto.request.PaymentCancelRequest;
 import com.example.whathis.payment.service.PaymentService;
@@ -35,11 +36,20 @@ public class OrderController {
     }
 
     @GetMapping("/my")
-    public ResponseEntity<ApiResponse<List<OrderCreateResponse>>> getMyOrders(
+    public ResponseEntity<ApiResponse<List<OrderResponse>>> getMyOrders(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        List<OrderCreateResponse> responses = orderService.getOrderByUser(userDetails.getUser());
+        List<OrderResponse> responses = orderService.getOrderByUser(userDetails.getUser());
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responses));
+    }
+
+    @GetMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<OrderResponse>> getOrderById(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long orderId
+    ) {
+        OrderResponse response = orderService.getOrderByUserAndId(userDetails.getUser(), orderId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
     }
 
     @PostMapping("/cancel")

--- a/src/main/java/com/example/whathis/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/example/whathis/order/dto/response/OrderResponse.java
@@ -1,0 +1,49 @@
+package com.example.whathis.order.dto.response;
+
+import com.example.whathis.common.order.OrderStatus;
+import com.example.whathis.order.entity.Order;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class OrderResponse {
+    // 상품 정보
+    private Long orderId;
+    private String merchantUid;
+    private String productName;
+    private String productImageUrl;
+    private LocalDateTime orderDate;
+    private LocalDateTime endDate;
+
+    // 구매 정보
+    private Integer quantity;
+    private BigDecimal totalAmount;
+    private OrderStatus orderStatus;
+    private String receiverName;
+    private String receiverPhone;
+    private String receiverAddress;
+    private String requestNote;
+
+    public static OrderResponse from(Order order) {
+        return OrderResponse.builder()
+                .orderId(order.getId())
+                .merchantUid(order.getOrderNumber())
+                .productName(order.getProduct().getTitle())
+                .productImageUrl(order.getProduct().getThumbnailImageUrl())
+                .orderDate(order.getReservedPaymentDate())
+                .endDate(order.getProduct().getEndDate())
+                .quantity(order.getQuantity())
+                .totalAmount(order.getTotalAmount())
+                .orderStatus(order.getStatus())
+                .receiverName(order.getReceiverName())
+                .receiverPhone(order.getReceiverPhone())
+                .receiverAddress(order.getReceiverAddress())
+                .requestNote(order.getRequest())
+                .build();
+    }
+}

--- a/src/main/java/com/example/whathis/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/example/whathis/order/dto/response/OrderResponse.java
@@ -35,7 +35,7 @@ public class OrderResponse {
                 .merchantUid(order.getOrderNumber())
                 .productName(order.getProduct().getTitle())
                 .productImageUrl(order.getProduct().getThumbnailImageUrl())
-                .orderDate(order.getReservedPaymentDate())
+                .orderDate(order.getCreatedAt())
                 .endDate(order.getProduct().getEndDate())
                 .quantity(order.getQuantity())
                 .totalAmount(order.getTotalAmount())

--- a/src/main/java/com/example/whathis/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/whathis/order/repository/OrderRepository.java
@@ -1,6 +1,7 @@
 package com.example.whathis.order.repository;
 
 import com.example.whathis.order.entity.Order;
+import com.example.whathis.product.entity.Product;
 import com.example.whathis.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,8 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByOrderNumber(String orderNumber);
 
     List<Order> findAllByBuyerOrderByIdDesc(User buyer);
+
+    List<Order> findAllByProduct(Product product);
+
+    Optional<Order> findByBuyerAndId(User buyer, Long orderId);
 }

--- a/src/main/java/com/example/whathis/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/whathis/order/repository/OrderRepository.java
@@ -4,6 +4,8 @@ import com.example.whathis.order.entity.Order;
 import com.example.whathis.product.entity.Product;
 import com.example.whathis.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -17,5 +19,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     List<Order> findAllByProduct(Product product);
 
-    Optional<Order> findByBuyerAndId(User buyer, Long orderId);
+
+    @Query("SELECT o FROM Order o JOIN FETCH o.product WHERE o.buyer = :buyer AND o.id = :orderId")
+    Optional<Order> findByBuyerAndId(@Param("buyer") User buyer, @Param("orderId") Long orderId);
 }

--- a/src/main/java/com/example/whathis/order/service/OrderService.java
+++ b/src/main/java/com/example/whathis/order/service/OrderService.java
@@ -5,6 +5,7 @@ import com.example.whathis.common.exception.ErrorCode;
 import com.example.whathis.common.order.OrderStatus;
 import com.example.whathis.order.dto.request.OrderCreateRequest;
 import com.example.whathis.order.dto.response.OrderCreateResponse;
+import com.example.whathis.order.dto.response.OrderResponse;
 import com.example.whathis.order.entity.Order;
 import com.example.whathis.order.repository.OrderRepository;
 import com.example.whathis.product.entity.Product;
@@ -58,11 +59,19 @@ public class OrderService {
     }
 
     @Transactional(readOnly = true)
-    public List<OrderCreateResponse> getOrderByUser(User buyer) {
+    public List<OrderResponse> getOrderByUser(User buyer) {
         List<Order> orders = orderRepository.findAllByBuyerOrderByIdDesc(buyer);
 
         return orders.stream()
-                .map(OrderCreateResponse::from)
+                .map(OrderResponse::from)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public OrderResponse getOrderByUserAndId(User buyer, Long orderId) {
+        Order order = orderRepository.findByBuyerAndId(buyer, orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        return OrderResponse.from(order);
     }
 }


### PR DESCRIPTION
사용자가 참여한 펀딩에 대한 상세 내역을 조회하는 API를 작성했습니다.

## 작업 내용
- `OrderResponse`: 주문 상세 내역 조회를 위한 DTO 작성
- `OrderService`, `OrderController`: 주문 상세 내역 조회 로직 및 API 작성

## 테스트
[전체 주문 내역 조회]
<img width="1396" height="866" alt="image" src="https://github.com/user-attachments/assets/da34ac97-5578-4fe3-816b-78c6cb822733" />

[상세 주문 내역 조회]
<img width="1400" height="812" alt="image" src="https://github.com/user-attachments/assets/2573a25e-12de-4524-b29e-7a8da060f11e" />

Close #64 