### PR TITLE
feat/User: 사용자 삭제 시 외래키 제약 조건 오류 방지를 위한 로직 및 메서드 추가

### DIFF
--- a/src/main/java/com/example/whathis/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/whathis/order/repository/OrderRepository.java
@@ -22,4 +22,10 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     @Query("SELECT o FROM Order o JOIN FETCH o.product WHERE o.buyer = :buyer AND o.id = :orderId")
     Optional<Order> findByBuyerAndId(@Param("buyer") User buyer, @Param("orderId") Long orderId);
+
+    // 구매자가 해당 유저인 모든 주문을 삭제
+    void deleteAllByBuyer(User buyer);
+
+    // 상품의 판매자가 해당 유저인 모든 주문을 삭제
+    void deleteAllByProductSeller(User seller);
 }

--- a/src/main/java/com/example/whathis/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/example/whathis/payment/repository/PaymentRepository.java
@@ -2,6 +2,7 @@ package com.example.whathis.payment.repository;
 
 import com.example.whathis.order.entity.Order;
 import com.example.whathis.payment.entity.Payment;
+import com.example.whathis.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,10 @@ import java.util.Optional;
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByOrder(Order order);
+
+    // 해당 유저가 결제한 내역 모두 삭제
+    void deleteAllByUser(User user);
+
+    // 해당 유저의 상품에 연관된 결제 내역 모두 삭제
+    void deleteAllByOrderProductSeller(User user);
 }

--- a/src/main/java/com/example/whathis/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/whathis/product/repository/ProductRepository.java
@@ -4,6 +4,8 @@ import com.example.whathis.product.entity.Product;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+
+import com.example.whathis.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -83,4 +85,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "AND p.endDate > CURRENT_TIMESTAMP " +
             "ORDER BY p.createdAt DESC")
     List<Product> findProductsByFollowerId(@Param("followerId") Long followerId);
+
+    void deleteAllBySeller(User seller);
 }

--- a/src/main/java/com/example/whathis/productlike/repository/ProductLikeRepository.java
+++ b/src/main/java/com/example/whathis/productlike/repository/ProductLikeRepository.java
@@ -3,6 +3,8 @@ package com.example.whathis.productlike.repository;
 import com.example.whathis.productlike.entity.ProductLike;
 import java.util.List;
 import java.util.Optional;
+
+import com.example.whathis.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -21,4 +23,9 @@ public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> 
     // 사용자가 좋아요를 누른 모든 상품 조회
     List<ProductLike> findAllByUserId(Long userId);
 
+    // 해당 유저가 누른 좋아요 모두 삭제
+    void deleteAllByUser(User user);
+
+    // 해당 유저의 상품에 눌린 좋아요 모두 삭제
+    void deleteAllByProductSeller(User user);
 }

--- a/src/main/java/com/example/whathis/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/whathis/review/repository/ReviewRepository.java
@@ -2,6 +2,8 @@ package com.example.whathis.review.repository;
 
 import com.example.whathis.review.entity.Review;
 import java.util.List;
+
+import com.example.whathis.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,4 +28,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             "FROM Review r " +
             "WHERE r.product.seller.id = :sellerId")
     Double findRatingAvgBySellerId(@Param("sellerId") Long sellerId);
+
+    // 해당 유저의 리뷰 모두 삭제
+    void deleteAllByUser(User user);
+
+    // 해당 유저의 상품에 달린 리뷰 모두 삭제
+    void deleteAllByProductSeller(User seller);
 }

--- a/src/main/java/com/example/whathis/user/service/UserService.java
+++ b/src/main/java/com/example/whathis/user/service/UserService.java
@@ -9,10 +9,13 @@ import com.example.whathis.auth.dto.request.LoginRequest;
 import com.example.whathis.auth.dto.request.SignupRequest;
 import com.example.whathis.auth.dto.response.TokenResponse;
 import com.example.whathis.follow.repository.FollowRepository;
+import com.example.whathis.order.repository.OrderRepository;
+import com.example.whathis.payment.repository.PaymentRepository;
 import com.example.whathis.product.dto.response.ProductResponse;
 import com.example.whathis.product.dto.response.UserProfileResponse;
 import com.example.whathis.product.entity.Product;
 import com.example.whathis.product.repository.ProductRepository;
+import com.example.whathis.productlike.repository.ProductLikeRepository;
 import com.example.whathis.review.repository.ReviewRepository;
 import com.example.whathis.user.dto.response.UserResponse;
 import com.example.whathis.user.entity.User;
@@ -36,6 +39,9 @@ public class UserService {
     private final FollowRepository followRepository;
     private final ReviewRepository reviewRepository;
     private final ProductRepository productRepository;
+    private final OrderRepository orderRepository;
+    private final ProductLikeRepository productLikeRepository;
+    private final PaymentRepository paymentRepository;
 
     @Transactional(readOnly = true)
     public UserResponse getProfile(User user) {
@@ -88,7 +94,22 @@ public class UserService {
         followRepository.deleteByFollower(currentUser);
         followRepository.deleteByFollowing(currentUser);
 
-        // 진행중인 펀딩이나 주문이 있는지 확인하는 로직은 추후에 추가
+        // 구매자 입장에서 관련된 결제, 주문, 리뷰, 좋아요 삭제
+        paymentRepository.deleteAllByUser(currentUser);
+        orderRepository.deleteAllByBuyer(currentUser);
+        reviewRepository.deleteAllByUser(currentUser);
+        productLikeRepository.deleteAllByUser(currentUser);
+
+        // 판매자 입장에서 내 상품과 관련된 데이터(결제, 주문, 리뷰, 좋아요) 삭제 후 상품 삭제
+        paymentRepository.deleteAllByOrderProductSeller(currentUser);
+        orderRepository.deleteAllByProductSeller(currentUser);
+        reviewRepository.deleteAllByProductSeller(currentUser);
+        productLikeRepository.deleteAllByProductSeller(currentUser);
+
+        // 상품 삭제
+        productRepository.deleteAllBySeller(currentUser);
+
+        // 사용자 삭제
         userRepository.delete(currentUser);
     }
 


### PR DESCRIPTION
사용자 탈퇴 시 외래키 제약 조건 오류 방지를 위해 사용자 삭제 전 사용자의 결제, 주문, 리뷰, 좋아요를 삭제한 뒤 사용자를 삭제하는 로직을 작성했습니다.
결제, 주문, 리뷰, 좋아요 모두 사용자가 구매자 입장에서 직접 남긴 것과 판매자 입장에서 사용자의 상품에 남겨진 것을 각각 삭제하는 메서드를 작성했습니다.