### PR TITLE
fix/User: 프로필 수정 시 중복 닉네임 에러 해결

### DIFF
--- a/src/main/java/com/example/whathis/user/service/UserService.java
+++ b/src/main/java/com/example/whathis/user/service/UserService.java
@@ -53,11 +53,12 @@ public class UserService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         if (request.getNickname() != null) {
-            if (currentUser.getNickname().equals(request.getNickname())) {
-                throw new BusinessException(ErrorCode.SAME_AS_CURRENT_NICKNAME);
-            }
-            if (userRepository.existsByNickname(request.getNickname())) {
-                throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+            // 현재 내 닉네임과 다르다면 중복 검사
+            // 현재 내 닉네임과 같다면 검사 생략
+            if (!currentUser.getNickname().equals(request.getNickname())) {
+                if (userRepository.existsByNickname(request.getNickname())) {
+                    throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+                }
             }
         }
 


### PR DESCRIPTION
사용자 프로필 수정 시 닉네이 중복 에러를 해결하기 위해 현재 닉네임과 같은 경우는 중복 검사 생략하도록 수정했습니다.